### PR TITLE
feat: add /copy skill with format selection

### DIFF
--- a/template/.claude/skills/copy/SKILL.md
+++ b/template/.claude/skills/copy/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: copy
+description: Copy content to clipboard in a format suited to the target (Slack, Markdown, plain text). Use when the user says "clip", "copy that", "clipboard", or "/copy".
+allowed-tools: Bash, AskUserQuestion
+user-invocable: true
+---
+
+# Copy to Clipboard
+
+Copies the most recent output (or specified content) to the clipboard in the right format for the user's target.
+
+## Steps
+
+1. **Ask the user** (unless they already specified): "Where is this going? (slack / md / plain)"
+
+2. **Format based on target:**
+
+   **`slack`** — Slack uses `mrkdwn`, NOT Markdown. Convert:
+   - `*bold*` (not `**bold**`)
+   - `_italic_` (not `*italic*`)
+   - `~strikethrough~` (not `~~strikethrough~~`)
+   - `*HEADING*` on its own line (no `#` headings)
+   - No markdown tables — use code-block ASCII tables (triple backtick) or bullet lists
+   - `<url|text>` links (not `[text](url)`)
+   - Code: single backtick for inline, triple backtick for blocks (same as markdown)
+
+   **`md`** — Clean GitHub-Flavored Markdown:
+   - Tables, headings, links all standard GFM
+   - No hard wraps, no gutter artifacts, no line-number prefixes
+
+   **`plain`** — No formatting at all:
+   - Strip all markup
+   - Use indentation and whitespace for structure
+
+3. **Copy to clipboard** using the platform tool:
+   - macOS: `pbcopy`
+   - Linux: `xclip -selection clipboard` or `xsel --clipboard`
+   - Windows/WSL: `clip.exe`
+
+4. **Confirm** with a one-line message: "Copied (slack/md/plain) — N lines"
+
+## Notes
+
+- If the user says just "copy that" or "clip" without a target, always ask.
+- If they say "copy for slack" or "slack copy", skip the question — target is `slack`.
+- If they say "copy" with no prior output to copy, ask what they want copied.

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -101,7 +101,7 @@ Standard schemas:
 - `{assumptions, facts[], decisions[], risks[], next_steps[]}`
 - `claim | evidence | confidence | action`
 
-**Clipboard on request only.** Never auto-copy to clipboard — it overwrites whatever the user has there. Only copy when the user explicitly asks ("clip", "copy that", "clipboard"). Use the platform's clipboard tool: `pbcopy` (macOS), `xclip -selection clipboard` or `xsel --clipboard` (Linux), `clip.exe` (Windows/WSL). When they do: clean markdown, no hard wraps, no gutter artifacts.
+**Clipboard on request only.** Never auto-copy to clipboard — it overwrites whatever the user has there. Only copy when the user explicitly asks ("clip", "copy that", "clipboard") — use `/copy` for format selection. Use the platform's clipboard tool: `pbcopy` (macOS), `xclip -selection clipboard` or `xsel --clipboard` (Linux), `clip.exe` (Windows/WSL).
 
 **Respect execution mode.** When the user says "do NOT switch to plan mode" or asks you to execute autonomously/unattended, do NOT use TaskCreate, TaskUpdate, or EnterPlanMode. These tools trigger interactive permission prompts that break autonomous execution — even re-entering bypass mode doesn't suppress them. Just execute directly, reporting progress via text output.
 


### PR DESCRIPTION
## Summary
- New `/copy` skill that asks the user where content is going (Slack / Markdown / plain) and formats accordingly
- Slack uses `mrkdwn`, not Markdown — tables don't render, `**bold**` doesn't work, links use `<url|text>`. The skill handles all conversions.
- Updated clipboard rule in `template/CLAUDE.md` to point to `/copy` instead of hardcoding one format

## Test plan
- [ ] Run `bash init.sh /tmp/mv-test` — verify `copy/SKILL.md` is deployed
- [ ] In a megavibe session, type `/copy` — should ask for target format
- [ ] Say "copy for slack" — should skip the question and use mrkdwn