### PR TITLE
gemini-review: cheap default model + --auto escalation to Pro

### DIFF
--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -30,16 +30,35 @@
 
 set -euo pipefail
 
-# Measured 2026-09-06: gemini-flash-latest → gemini-3.8-flash; --pro → gemini-3.1-pro-preview
+# Measured 2026-09-10: default is now the pinned gemini-3.1-flash-lite (cheapest
+# non-deprecated tier). NOT the `gemini-flash-lite-latest` alias — it answered with
+# no text part at all in testing, so it is unreliable for scripted use; pinned
+# lite versions (3.1, 3.5) both answer correctly with thinkingLevel.
+# gemini-flash-latest still resolves to gemini-3.8-flash if you want the bigger model.
 # (the current Pro line; answered live that day). Both accept thinkingConfig.thinkingLevel.
 # If Google moves the alias to a model that rejects the field, the API returns 400 and
 # this script exits 1 with the message — re-check `models?key=` and adjust MODEL/--pro.
-MODEL="gemini-flash-latest"; LEVEL="low"; MAX=16000; OUT=""; PROMPT=""; PROMPT_FILE=""
+MODEL="gemini-3.1-flash-lite"; LEVEL="low"; MAX=16000; OUT=""; PROMPT=""; PROMPT_FILE=""
+# --auto: review on the cheap model, escalate to Pro only when warranted.
+#
+# Self-reported confidence is deliberately NOT the only gate. A model that misses
+# a blocker does not know it missed it — confidence tracks fluency, not accuracy,
+# so "no findings, confidence 0.95" is exactly the failure this is meant to catch.
+# Escalation therefore fires on ANY of four signals, three of which do not depend
+# on the model's own introspection:
+#   1. it reported a blocker/major finding      (its findings, not its confidence)
+#   2. self-reported confidence below threshold (weakest signal; a tiebreak only)
+#   3. it reported partial coverage, or emitted no parseable verdict at all
+#   4. the INPUT is high-stakes by deterministic file match — fires even when the
+#      cheap model says everything is fine
+AUTO=""; MIN_CONF="0.75"; PRO_MODEL="gemini-3.1-pro-preview"; PRO_LEVEL="medium"
 FILES=()
 need(){ [ $# -ge 2 ] || { echo "error: $1 needs a value" >&2; exit 2; }; }
 while [ $# -gt 0 ]; do
   case "$1" in
-    --pro)         MODEL="gemini-3.1-pro-preview"; LEVEL="medium"; shift ;;
+    --pro)         MODEL="$PRO_MODEL"; LEVEL="$PRO_LEVEL"; shift ;;
+    --auto)        AUTO=1; shift ;;
+    --min-conf)    need "$@"; MIN_CONF="$2"; shift 2 ;;
     --model)       need "$@"; MODEL="$2"; shift 2 ;;
     --level)       need "$@"; LEVEL="$2"; shift 2 ;;
     --max)         need "$@"; MAX="$2"; shift 2 ;;
@@ -65,16 +84,42 @@ command -v jq &>/dev/null || { echo "error: jq is required" >&2; exit 1; }
 # through argv. jq -Rs escapes the text exactly.
 REQ=$(mktemp -t gemini-req)
 if [ -n "$OUT" ]; then RAW="$OUT.raw.json"; KEEP_RAW=1; else RAW=$(mktemp -t gemini-raw); KEEP_RAW=""; fi
-trap '[ -n "$KEEP_RAW" ] || rm -f "$RAW"; rm -f "$REQ"' EXIT
+trap '[ -n "$KEEP_RAW" ] || rm -f "$RAW"; rm -f "$REQ" "$REQ.txt"' EXIT
+AUTO_SUFFIX=''
+if [ -n "$AUTO" ]; then
+  AUTO_SUFFIX=$(cat <<'SUF'
+
+---
+After your review, emit EXACTLY this line last, on its own, nothing after it:
+
+<<<VERDICT severity=SEV confidence=CONF coverage=COV>>>
+
+  SEV   = blocker | major | minor | none   (the most severe issue you actually found)
+  CONF  = 0.00-1.00, how confident you are that you found everything that matters
+  COV   = full | partial   ("partial" if anything stopped you reviewing properly:
+          missing files, truncated input, code you could not follow, or a change
+          whose consequences you cannot see from what was provided)
+
+Be honest about partial coverage and about low confidence. A cheap model saying
+"none / 1.00" on work it did not fully understand is worse than useless — an
+honest "partial" costs one extra call, a false "full" ships a defect.
+SUF
+)
+fi
+
 {
   printf '%s\n' "$PROMPT"
+  [ -n "$AUTO_SUFFIX" ] && printf '%s\n' "$AUTO_SUFFIX"
   for f in "${FILES[@]:-}"; do
     [ -n "$f" ] || continue
     [ -f "$f" ] && [ -r "$f" ] || { echo "error: not a readable file: $f" >&2; exit 1; }
     printf '\n\n===== %s =====\n' "$f"; cat -- "$f"
   done
-} | jq -Rs --arg model "$MODEL" --arg level "$LEVEL" --argjson max "$MAX" \
-  '{contents:[{parts:[{text:.}]}], generationConfig:{maxOutputTokens:$max, temperature:0.2, thinkingConfig:{thinkingLevel:$level}}}' > "$REQ"
+} > "$REQ.txt"
+build_req(){ jq -Rs --arg level "$1" --argjson max "$MAX" \
+  '{contents:[{parts:[{text:.}]}], generationConfig:{maxOutputTokens:$max, temperature:0.2, thinkingConfig:{thinkingLevel:$level}}}' \
+  < "$REQ.txt" > "$REQ"; }
+build_req "$LEVEL"
 
 call(){ curl -s --max-time 280 -X POST \
   "https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent" \
@@ -98,6 +143,55 @@ TEXT=$(printf '%s' "$BODY" | jq -r '[.candidates[0].content.parts[]? | select(.t
 FINISH=$(printf '%s' "$BODY" | jq -r '.candidates[0].finishReason // "?"')
 USAGE=$(printf '%s' "$BODY" | jq -r '.usageMetadata | "in=\(.promptTokenCount // "?") out=\(.candidatesTokenCount // "?") thoughts=\(.thoughtsTokenCount // 0)"')
 MV=$(printf '%s' "$BODY" | jq -r '.modelVersion // "?"')
+
+if [ -n "$AUTO" ]; then
+  V=$(printf '%s' "$TEXT" | grep -oE '<<<VERDICT[^>]*>>>' | tail -1)
+  SEV=$(printf '%s' "$V" | grep -oE 'severity=[a-z]+' | cut -d= -f2)
+  CONF=$(printf '%s' "$V" | grep -oE 'confidence=[0-9.]+' | cut -d= -f2)
+  COV=$(printf '%s' "$V" | grep -oE 'coverage=[a-z]+' | cut -d= -f2)
+
+  # (4) Deterministic high-stakes match on the INPUT — independent of the model.
+  # These are the paths where a missed defect is expensive, so they always get
+  # the stronger reviewer regardless of how confident the cheap one sounded.
+  STAKES=""
+  for f in "${FILES[@]:-}"; do
+    case "$f" in
+      *auth*|*Auth*|*credential*|*secret*|*token*|*passwd*|*password*|*crypto*|*key*.py|\
+      *payment*|*billing*|*invoice*|*charge*|*refund*|\
+      *migration*|*migrate*|*schema*|*delete*|*destroy*|*drop*|*purge*|\
+      *CLAUDE.md|*README*.md|*SKILL.md|*.github/workflows/*)
+        STAKES="$f"; break ;;
+    esac
+  done
+
+  WHY=""
+  case "$SEV" in blocker|major) WHY="found a $SEV finding" ;; esac
+  [ -z "$WHY" ] && [ -z "$V" ] && WHY="emitted no parseable verdict"
+  [ -z "$WHY" ] && [ "$COV" != "full" ] && WHY="reported coverage=$COV"
+  [ -z "$WHY" ] && [ -n "$CONF" ] && awk -v c="$CONF" -v m="$MIN_CONF" 'BEGIN{exit !(c<m)}' \
+    && WHY="confidence $CONF < $MIN_CONF"
+  [ -z "$WHY" ] && [ -n "$STAKES" ] && WHY="high-stakes input ($STAKES)"
+
+  if [ -n "$WHY" ]; then
+    echo "[gemini-review: escalating to $PRO_MODEL — $WHY]" >&2
+    CHEAP_TEXT="$TEXT"; CHEAP_MV="$MV"; CHEAP_USAGE="$USAGE"
+    MODEL="$PRO_MODEL"; LEVEL="$PRO_LEVEL"; build_req "$PRO_LEVEL"
+    BODY=$(call || true)
+    if printf '%s' "$BODY" | jq -e '.candidates[0].content.parts' >/dev/null 2>&1; then
+      TEXT=$(printf '%s' "$BODY" | jq -r '[.candidates[0].content.parts[]? | select(.thought != true) | .text // empty] | join("")')
+      FINISH=$(printf '%s' "$BODY" | jq -r '.candidates[0].finishReason // "?"')
+      USAGE=$(printf '%s' "$BODY" | jq -r '.usageMetadata | "in=\(.promptTokenCount // "?") out=\(.candidatesTokenCount // "?") thoughts=\(.thoughtsTokenCount // 0)"')
+      MV=$(printf '%s' "$BODY" | jq -r '.modelVersion // "?"')
+      USAGE="$USAGE (escalated from $CHEAP_MV: $CHEAP_USAGE)"
+    else
+      # Pro failed: keep the cheap review rather than returning nothing, and say so.
+      echo "warning: escalation call failed — returning the $CHEAP_MV review" >&2
+      TEXT="$CHEAP_TEXT"
+    fi
+  else
+    echo "[gemini-review: no escalation — severity=$SEV confidence=$CONF coverage=$COV]" >&2
+  fi
+fi
 
 if [ -n "$OUT" ]; then printf '%s\n' "$TEXT" > "$OUT"; fi
 printf '%s\n' "$TEXT"


### PR DESCRIPTION
### 1. Cheaper default model

`gemini-flash-latest` (→ 3.8-flash) → pinned **`gemini-3.1-flash-lite`**.

Not the `gemini-flash-lite-latest` alias — it returned a response with **no text part at all** in testing, so it is unreliable for scripted use. Pinned 3.1 and 3.5 lite both answer correctly with `thinkingConfig.thinkingLevel`.

### 2. `--auto`: escalate to Pro only when warranted

The obvious design is "ask for confidence, escalate when it's low". **That alone does not work.** A model that misses a blocker doesn't know it missed it — confidence tracks fluency, not accuracy — so the dangerous case ("no findings, confidence 0.95" on an incomplete review) reports the same number as a genuinely clean one.

Escalation fires on **any** of four signals, three independent of the model's self-assessment:

| # | signal | self-assessed? |
|---|---|---|
| 1 | reported a blocker/major finding | no — its findings |
| 2 | confidence < `--min-conf` (default 0.75) | yes — tiebreak only |
| 3 | `coverage != full`, or no parseable verdict | fails **open** to Pro |
| 4 | deterministic high-stakes path match | no — the input |

Signal 4 covers `auth`/`credential`/`payment`/`migration`/`delete`/`CLAUDE.md`/`README*`/`SKILL.md`/workflows, which also makes the protocol's "use `--pro` for protocol/template/user-facing changes" rule automatic instead of something to remember.

**Verified live:** on `payment_utils.py` the cheap model returned `severity=none confidence=0.95 coverage=full`. A confidence gate accepts that; the filename match escalated anyway.

A failed Pro call falls back to the cheap review with a warning rather than returning nothing. All six decision branches unit-tested.

Cost: ~$0.01 when it stays on lite, ~$0.15 when it escalates.

https://claude.ai/code/session_01AzsC9a5irJ5g6MRyy3N78L