### PR TITLE
scripts: publish google-oauth-mint.sh; reap poma-serve with the last session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Megavibe is a bootstrapper + protocol for AI-assisted development. It is NOT a s
 | `.claude/rules/*.md` | Live rules for THIS repo (copied from template) | Should mirror template |
 | `.claude/agents/*.md` | Live agents for THIS repo (copied from template) | Should mirror template |
 | `megawork/` | Derived profile Megawork — the profile for non-technical colleagues | Medium — see `megawork/README.md` |
+| `scripts/google-oauth-mint.sh` | Per-user Google OAuth refresh token for scopes a gcloud login does not carry (Ads, Workspace Admin, GA4 Admin). Loopback consent, token 0600 in ~/.config. `groupwrite` is a WRITE scope — see the header | Medium — touches credentials |
 | `scripts/mint-gemini-key.sh`, `pick-gemini-model.sh` | Admin-side Gemini key minting on the billed project (now the default; `--free-tier` opts into the dropped mode), and flash-model probing. Free-tier keys are 20 req/day and train on prompts — not a backend | Medium — touches credentials |
 | `README-watcher.md` | Context-watcher detail | Low |
 | `.agent/` | Live context for developing megavibe itself | Continuous |

--- a/scripts/google-oauth-mint.sh
+++ b/scripts/google-oauth-mint.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Mint a per-user Google OAuth refresh token for an arbitrary scope set, via a
+# localhost loopback consent flow.
+#
+# Why this exists: a `gcloud` login (and the Gemini CLI's stored grant) carries
+# the cloud-platform scope ONLY. That does not cover the Google Ads API
+# (adwords), the Workspace Admin SDK (admin.directory.*), or GA4 Admin
+# (analytics.*) — each needs its own consent. This performs that consent once per
+# scope family and stores the refresh token, so later automated runs are
+# non-interactive.
+#
+# Each user runs this as THEMSELVES. The resulting token carries that person's
+# own authority — no shared credential, no domain-wide delegation, and access
+# dies with their account. That is the property you want for offboarding.
+#
+# Usage:
+#   google-oauth-mint.sh ads         # https://www.googleapis.com/auth/adwords
+#   google-oauth-mint.sh workspace   # admin.directory.{user,group,rolemanagement}.readonly
+#   google-oauth-mint.sh groupwrite  # admin.directory.group  (member/role writes)
+#   google-oauth-mint.sh analytics   # analytics.manage.users + analytics.readonly
+#   google-oauth-mint.sh custom "scope1 scope2" outname
+#
+# Requires an OAuth client of type "Desktop app" in any Google Cloud project you
+# control, as GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET. Tokens land in
+# ~/.config/google-<name>-refresh-token.json, mode 0600.
+#
+# WARNING on `groupwrite`: admin.directory.group is a WRITE scope over Workspace
+# group membership, so the refresh token it stores can change who is in which
+# group — a privilege-escalation primitive sitting in a file with no expiry.
+# Mint it only if you need it, and revoke at myaccount.google.com/permissions
+# when you are done.
+#
+# Known gap, deliberate: no PKCE. Google recommends it for loopback clients, and
+# it belongs here, but it is unverified in this script and an untested auth
+# change is worse than a documented one. See the repo issue before relying on
+# this for anything beyond an internal tool.
+
+set -euo pipefail
+# Accept the generic names first; the older GOOGLE_ADS_API_* names still work so
+# an existing shell profile keeps running unchanged.
+CLIENT_ID="${GOOGLE_OAUTH_CLIENT_ID:-${GOOGLE_ADS_API_CLIENT:-}}"
+CLIENT_SECRET="${GOOGLE_OAUTH_CLIENT_SECRET:-${GOOGLE_ADS_API_SECRET:-}}"
+[ -n "$CLIENT_ID" ] && [ -n "$CLIENT_SECRET" ] || {
+  echo "Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET first." >&2
+  echo "Create the client in Google Cloud console → APIs & Services → Credentials" >&2
+  echo "→ Create credentials → OAuth client ID → Desktop app. Enable the APIs you" >&2
+  echo "want scopes for on the same project." >&2
+  exit 2
+}
+export CLIENT_ID CLIENT_SECRET
+
+case "${1:-}" in
+  ads)        SCOPES="https://www.googleapis.com/auth/adwords"; NAME=ads ;;
+  workspace)  SCOPES="https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly https://www.googleapis.com/auth/admin.directory.user.readonly https://www.googleapis.com/auth/admin.directory.group.readonly"; NAME=workspace ;;
+  groupwrite) SCOPES="https://www.googleapis.com/auth/admin.directory.group"; NAME=groups ;;
+  analytics)  SCOPES="https://www.googleapis.com/auth/analytics.manage.users https://www.googleapis.com/auth/analytics.readonly"; NAME=analytics ;;
+  custom)     SCOPES="${2:?scopes}"; NAME="${3:?output name}" ;;
+  *) sed -n '2,26p' "$0"; exit 2 ;;
+esac
+
+PORT="${OAUTH_PORT:-8770}" SCOPES="$SCOPES" NAME="$NAME" python3 - <<'PY'
+import os, sys, json, time, threading, http.server, urllib.parse, urllib.request
+
+port = int(os.environ["PORT"]); scopes = os.environ["SCOPES"]; name = os.environ["NAME"]
+cid, csec = os.environ["CLIENT_ID"], os.environ["CLIENT_SECRET"]
+redirect = f"http://localhost:{port}/"
+box = {}
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        box.update({k: v[0] for k, v in
+                    urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query).items()})
+        self.send_response(200); self.send_header("Content-Type", "text/html"); self.end_headers()
+        self.wfile.write(b"<h2>Done. Close this tab.</h2>")
+    def log_message(self, *a): pass
+
+srv = http.server.HTTPServer(("127.0.0.1", port), H)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+url = "https://accounts.google.com/o/oauth2/v2/auth?" + urllib.parse.urlencode({
+    "client_id": cid, "redirect_uri": redirect, "response_type": "code",
+    "scope": scopes, "access_type": "offline", "prompt": "consent"})
+print("Open this URL and approve:\n" + url + "\n", flush=True)
+
+t0 = time.time()
+while "code" not in box and "error" not in box and time.time() - t0 < 300:
+    time.sleep(1)
+if "code" not in box:
+    sys.exit("no authorization code received: %s" % json.dumps(box))
+
+tok = json.load(urllib.request.urlopen(urllib.request.Request(
+    "https://oauth2.googleapis.com/token",
+    data=urllib.parse.urlencode({"code": box["code"], "client_id": cid,
+        "client_secret": csec, "redirect_uri": redirect,
+        "grant_type": "authorization_code"}).encode())))
+if "refresh_token" not in tok:
+    sys.exit("no refresh_token returned (already-granted consent? re-run revokes nothing; "
+             "remove the app at myaccount.google.com/permissions and retry)")
+
+out = os.path.expanduser(f"~/.config/google-{name}-refresh-token.json")
+fd = os.open(out, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w") as f:
+    json.dump({"refresh_token": tok["refresh_token"], "scopes": scopes}, f)
+print("wrote " + out)
+PY

--- a/template/.claude/hooks/on-session-end.sh
+++ b/template/.claude/hooks/on-session-end.sh
@@ -32,4 +32,34 @@ TMUX_SESSION="mvw-${SID}"
 if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
   tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
 fi
+
+# The poma-memory search daemon is machine-wide, not per-session, so it is only
+# reapable once NOBODY is left to serve. Otherwise this hook would kill the warm
+# index out from under three other sessions.
+#
+# Observed, not counted. A reference count incremented at SessionStart and
+# decremented here leaks upward every time this hook does not run — a crash, a
+# kill -9, a laptop shutdown — and a leaked count means the daemon never exits,
+# which is worse than the 30-minute idle timer it would be replacing. Counting
+# live processes re-derives the truth every time and cannot drift.
+#
+# The idle timeout stays as the backstop for the case where this hook never
+# fires at all.
+if tmux has-session -t poma-serve 2>/dev/null; then
+  MY_PID="${PPID:-0}"
+  OTHERS=0
+  # Every claude process except our own parent; alive AND sitting in a directory
+  # that has a .agent, i.e. a megavibe project that would want the daemon.
+  for _p in $(pgrep -x claude 2>/dev/null); do
+    [ "$_p" = "$MY_PID" ] && continue
+    _cwd=$(lsof -a -p "$_p" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+    [ -n "$_cwd" ] && [ -d "$_cwd/.agent" ] && OTHERS=$((OTHERS+1))
+  done
+  if [ "$OTHERS" -eq 0 ]; then
+    tmux kill-session -t poma-serve 2>/dev/null || true
+    echo "$(date -u +%FT%TZ) poma-serve stopped: last megavibe session ended" \
+      >> .agent/LOGS/poma-serve-spawn.log 2>/dev/null || true
+  fi
+fi
+
 exit 0


### PR DESCRIPTION
## Summary

Two unrelated pieces, both small.

**`scripts/google-oauth-mint.sh`** — promoted from a private overlay. It holds no secrets and does nothing underhanded: it is the documented installed-app loopback flow for scopes a `gcloud` login does not carry (Ads, Workspace Admin SDK, GA4 Admin). The design is better than the usual alternative — each person runs it as themselves, the token carries their own authority, no shared credential, no domain-wide delegation, and access dies with their account.

Generalised for publication: env vars are now `GOOGLE_OAUTH_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_SECRET` with the old `GOOGLE_ADS_API_*` names still honoured, the org-specific project reference is gone, and how to create the OAuth client is in the header.

Two things called out rather than buried:
- `groupwrite` mints a **write** scope over Workspace group membership — a privilege-escalation primitive in a file with no expiry.
- **No PKCE.** Google recommends it for loopback clients and it belongs here, but it is unverified in this script, and an untested auth change is worse than a documented gap.

**`on-session-end.sh`** now reaps the poma-memory daemon when the session ending is the last megavibe session on the machine. Observed, not counted: a reference count incremented at SessionStart and decremented here leaks upward on every crash or `kill -9`, and a leaked count means the daemon never exits — worse than the idle timer it would replace. Counting live processes re-derives the truth and cannot drift. The 30-minute idle timeout stays as the backstop for when the hook never fires at all.

Measured, correcting an earlier claim of mine: the daemon costs **21MB idle, 71MB after a search** — not the 204MB I quoted, which was a daemon mid-work.

## Verification

- six sessions live → daemon spared; decoy with no claude processes → killed and logged; real daemon untouched throughout
- malformed stdin, missing tmux, and running outside a `.agent` project all exit 0
- script refuses cleanly with no client configured, resolves both env-var generations with the new name winning, and reaches the consent URL when credentials are present

https://claude.ai/code/session_0198Zf65uR4fiFZ9bmHDqLsJ