### PR TITLE
autopilot: force /rehydrate after compaction, and re-arm across cycles

### DIFF
--- a/template/.claude/hooks/compaction-autopilot.sh
+++ b/template/.claude/hooks/compaction-autopilot.sh
@@ -101,6 +101,47 @@ fi
 # Could not measure → do nothing at all. Never force on a guess.
 [ "$PCT" -gt 0 ] || exit 0
 
+# --- REHYDRATE comes first, always -----------------------------------------
+# Sequencing, deliberate: right after a compaction the window is nearly empty,
+# so the close-out thresholds cannot be met and these two can never contend for
+# the same Stop. The precedence is stated anyway, because "they cannot collide"
+# is exactly the assumption that stops being true after someone tunes a
+# threshold. Rehydrate wins; if it fires, this hook does nothing else.
+#
+# on-compact.sh sets .needs-rehydration when the working context is stale;
+# log-tool-event.sh clears it the moment WORKING_CONTEXT.md is written. So the
+# flag being gone is proof the work happened, not a promise that it will.
+REHYDRATE_FLAG="${LOGDIR}/.needs-rehydration.${SID}"
+R_NUDGE="${LOGDIR}/.rehydrate-nudge.${SID}"
+R_BLOCKED="${LOGDIR}/.rehydrate-blocked.${SID}"
+REHYDRATE_TASK='Run /rehydrate NOW, before anything else. The last compaction
+left the working context stale, and every answer until it is rebuilt is guesswork
+dressed as recall.'
+
+if [ -f "$REHYDRATE_FLAG" ]; then
+  if [ "$EVENT" = "PostToolUse" ]; then
+    if [ ! -f "$R_NUDGE" ]; then
+      : > "$R_NUDGE" 2>/dev/null || true
+      jq -n --arg c "$REHYDRATE_TASK" \
+        '{hookSpecificOutput:{hookEventName:"PostToolUse", additionalContext:$c}}' 2>/dev/null || true
+    fi
+    exit 0
+  fi
+  if [ "$EVENT" = "Stop" ]; then
+    ACTIVE=$(printf '%s' "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null) || ACTIVE="true"
+    [ "$ACTIVE" = "true" ] && exit 0
+    # Only escalate once the soft nudge has actually been delivered. Blocking on
+    # the first Stop after a compaction would fire before /rehydrate has had a
+    # single turn to run — and it spawns Gemini or Codex, which takes one.
+    [ -f "$R_NUDGE" ] || exit 0
+    [ -f "$R_BLOCKED" ] && exit 0
+    : > "$R_BLOCKED" 2>/dev/null || true
+    jq -n --arg r "$REHYDRATE_TASK" '{decision:"block", reason:$r}' 2>/dev/null || true
+    exit 0
+  fi
+  exit 0
+fi
+
 CLOSEOUT_TASK='Wrap up for compaction NOW, before doing anything else:
 1. Append the decisions of this session to .agent/DECISIONS.md — each with the
    reasoning, so nobody re-derives it. Not a list of what changed.

--- a/template/.claude/hooks/on-compact.sh
+++ b/template/.claude/hooks/on-compact.sh
@@ -62,6 +62,14 @@ mkdir -p "$SESSION_DIR"
 # summary just shed. (See augment-search.sh / reindex-agent.sh.)
 rm -f ".agent/LOGS/injected.${SID}.log" ".agent/LOGS/session-writes.${SID}.log" 2>/dev/null || true
 
+# Re-arm the compaction autopilot. Its flags are per-SESSION but the thing they
+# describe is per-FILL-CYCLE: after a compaction the window is nearly empty and
+# will fill again, so a .closeout-done left over from the previous cycle would
+# silence the hook for the rest of the session — the exact failure it exists to
+# prevent, reintroduced by its own success. Cleared here because this is the one
+# hook that runs at the cycle boundary.
+rm -f ".agent/LOGS/.closeout-done.${SID}"       ".agent/LOGS/.closeout-blocked.${SID}"       ".agent/LOGS/.closeout-count.${SID}"       ".agent/LOGS/.rehydrate-nudge.${SID}"       ".agent/LOGS/.rehydrate-blocked.${SID}" 2>/dev/null || true
+
 WC_PATH="${SESSION_DIR}/WORKING_CONTEXT.md"
 INSTRUCTIONS_FILE=".agent/LOGS/rehydration-instructions.${SID}.md"
 


### PR DESCRIPTION
## Summary

Two changes, one of which fixes a defect I shipped an hour ago.

**The defect.** `compaction-autopilot`s flags are per-**session** but the thing they describe is per-**fill-cycle**. After a compaction the window is nearly empty and fills again, so a `.closeout-done` left from the previous cycle silenced the hook for the rest of the session — the exact failure it exists to prevent, reintroduced by its own success. `on-compact.sh` now clears the closeout and rehydrate flags at the cycle boundary, scoped to its own session id so a concurrent session is untouched.

**The feature.** Rehydration was advisory: `on-compact.sh` set `.needs-rehydration`, `log-tool-event.sh` nagged, and whether it happened was left to the session. The autopilot now escalates it the same way as the close-out — one soft nudge, then a single `Stop` block.

**Sequencing**, which was the explicit ask. Rehydrate is checked **first** and returns early: if it fires, nothing else in the hook runs. Right after a compaction the window is nearly empty, so the close-out thresholds cannot be met and the two can never contend for the same `Stop` — but the precedence is written down anyway, because *"they cannot collide"* is exactly the assumption that stops being true after someone tunes a threshold.

**Running processes.** The `Stop` block only fires once the soft nudge has actually been delivered. Blocking on the first `Stop` after a compaction would fire before `/rehydrate` has had a single turn — and it spawns Gemini or Codex, which needs one. The flag is cleared by a `WORKING_CONTEXT` write, so its absence is proof the work happened rather than a promise that it will.

Also merges the one context-watcher staged decision not already recorded (D6b): the call not to rotate the plist credentials, with what containment did and did not buy.

## Verification

post-compaction at 20% context → rehydrate nudges once, blocks once, then quiet · flag cleared and context at 97% → the close-out takes the `Stop` instead · compaction clears five flags and leaves another session's alone

https://claude.ai/code/session_0198Zf65uR4fiFZ9bmHDqLsJ