### PR TITLE
hooks: key the sessions directory on the full session id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Two gotchas:
    - `[ -d ".agent" ] || exit 0` — no-op outside megavibe projects
    - `command -v jq &>/dev/null || exit 0` — graceful without jq
    - Never block Claude over infra issues (exit 0, not exit 2)
-   - Exception: `block-dangerous-bash.sh` and `enforce-pr-format.sh` exit 2 intentionally
+   - Exception: `block-dangerous-bash.sh`, `enforce-pr-format.sh` and `block-stray-working-context.sh` exit 2 intentionally
    - Exception: `block-dangerous-bash.sh` and `rm-to-trash.sh` intentionally run in every project (safety is universal), so they skip the `.agent` guard
 
 4. **Template/live parity.** `template/.claude/` and the repo's own `.claude/` should stay in sync. After editing a template hook, run `bash init.sh .` to sync the live copy.

--- a/template/.claude/hooks/block-stray-working-context.sh
+++ b/template/.claude/hooks/block-stray-working-context.sh
@@ -11,6 +11,11 @@ set -u
 #
 # Runs on Write|Edit|MultiEdit. No-op when jq is missing (graceful).
 
+# No-op outside a megavibe project (CLAUDE.md invariant 3). This hook exits 2,
+# and only block-dangerous-bash.sh and rm-to-trash.sh are licensed to do that
+# everywhere — a plain WORKING_CONTEXT.md in an unrelated repo is not megavibe's
+# business.
+[ -d ".agent" ] || exit 0
 command -v jq &>/dev/null || exit 0
 
 INPUT=$(cat)
@@ -30,12 +35,22 @@ BASENAME="${FILE_PATH##*/}"
 
 # Allow the canonical session-scoped path: anything ending in /.agent/sessions/<sid>/WORKING_CONTEXT.md
 # Reject everything else (project root, .agent/WORKING_CONTEXT.md, .agent/sessions/WORKING_CONTEXT.md, etc.)
-if [[ "$FILE_PATH" =~ /\.agent/sessions/[^/]+/WORKING_CONTEXT\.md$ ]]; then
-  exit 0
+# `[^/]+` alone also matched `..`, and .agent/sessions/../WORKING_CONTEXT.md
+# resolves to .agent/WORKING_CONTEXT.md — the precise stray path this hook
+# exists to reject, waved through by the pattern meant to catch it.
+# `(^|/)` and not a bare `/`: the relative spelling is the one this hook
+# ADVERTISES in its own suggestion, and a leading-slash-only pattern rejected
+# exactly that. Bash ERE has no non-capturing group, so the session component
+# is capture 2.
+if [[ "$FILE_PATH" =~ (^|/)\.agent/sessions/([^/]+)/WORKING_CONTEXT\.md$ ]]; then
+  case "${BASH_REMATCH[2]}" in
+    .|..) ;;
+    *) exit 0 ;;
+  esac
 fi
 
 # Try to extract session_id from hook stdin for a helpful suggested path
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null | cut -c1-11)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
 if [ -n "$SESSION_ID" ]; then
   SUGGESTED=".agent/sessions/${SESSION_ID}/WORKING_CONTEXT.md"
 else

--- a/template/.claude/hooks/block-stray-working-context.sh
+++ b/template/.claude/hooks/block-stray-working-context.sh
@@ -11,10 +11,9 @@ set -u
 #
 # Runs on Write|Edit|MultiEdit. No-op when jq is missing (graceful).
 
-# No-op outside a megavibe project (CLAUDE.md invariant 3). This hook exits 2,
-# and only block-dangerous-bash.sh and rm-to-trash.sh are licensed to do that
-# everywhere — a plain WORKING_CONTEXT.md in an unrelated repo is not megavibe's
-# business.
+# No-op outside a megavibe project (CLAUDE.md invariant 3). The guard-exempt
+# hooks are block-dangerous-bash.sh and rm-to-trash.sh, and this is neither: a
+# plain WORKING_CONTEXT.md in an unrelated repo is not megavibe's business.
 [ -d ".agent" ] || exit 0
 command -v jq &>/dev/null || exit 0
 

--- a/template/.claude/hooks/log-tool-event.sh
+++ b/template/.claude/hooks/log-tool-event.sh
@@ -55,6 +55,21 @@ mkdir -p "$LOGDIR" 2>/dev/null || true
 INPUT=$(cat)
 SID=$(echo "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null | cut -c1-12)
 SID="${SID:-default}"
+# The sessions DIRECTORY is keyed on the FULL session id, not the 12-char SID
+# used for flat flag files. /rehydrate derives its path from session_id in the
+# hook payload, so truncating here made the hook advertise one directory while
+# the skill wrote another: the stale-context hint read an empty file, and
+# .needs-rehydration never cleared because the file it watches was never the
+# file that got written.
+SID_FULL=$(echo "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null)
+SID_FULL="${SID_FULL:-default}"
+# Validate before it becomes a path component. session_id comes from the harness
+# and is a UUID in practice, but this string is interpolated into mkdir/read
+# targets, and "in practice" is not a boundary. Anything outside a safe charset
+# — or a bare . / .. — falls back to the same "default" the missing-id case uses.
+case "$SID_FULL" in
+  ''|.|..|*[!A-Za-z0-9._-]*) SID_FULL="default" ;;
+esac
 
 # Session-scoped paths (prevent concurrent session races)
 LOGFILE="${LOGDIR}/tool-events.${SID}.jsonl"
@@ -104,10 +119,21 @@ fi
 # jq output into the file (Bash), which produces no Write event. Generic fix:
 # if the canonical file exists and is newer than the flag, rehydration
 # happened — clear regardless of which tool wrote it. Two stats per call.
-SESSION_WC=".agent/sessions/${SID}/WORKING_CONTEXT.md"
-if [ -f "$REHYDRATE_FLAG" ] && [ -s "$SESSION_WC" ] && [ "$SESSION_WC" -nt "$REHYDRATE_FLAG" ]; then
-  rm -f "$REHYDRATE_FLAG" 2>/dev/null || true
-fi
+# Both spellings are checked: the full id is canonical, the 12-char one is what
+# a session that started before this fix wrote. The truncated path is NOT
+# strictly this session's — any session sharing the first 12 characters maps to
+# it, and so does the shared flag file itself. That collision predates this hook
+# and is negligible for UUIDs; it is recorded here rather than implied away,
+# because the previous wording claimed a scoping guarantee that does not exist.
+# What this loop does prove is mtime, not authorship: a fresh WORKING_CONTEXT is
+# inferred from "newer than the flag", so an unrelated touch also satisfies it.
+# The cost of that false positive is one skipped nudge, which is why it stands.
+for _wc in ".agent/sessions/${SID_FULL}/WORKING_CONTEXT.md" ".agent/sessions/${SID}/WORKING_CONTEXT.md"; do
+  [ -f "$REHYDRATE_FLAG" ] || break
+  if [ -s "$_wc" ] && [ "$_wc" -nt "$REHYDRATE_FLAG" ]; then
+    rm -f "$REHYDRATE_FLAG" 2>/dev/null || true
+  fi
+done
 
 # --- Generic mtime-based reset ---
 # Catches writes to .agent/*.md by any tool, not just Edit/Write. Bash
@@ -142,7 +168,13 @@ if [[ "$TOOL_NAME" =~ ^(Edit|Write)$ ]] && [[ "$FILE_PATH" == *".agent/"*".md" ]
   # Clear rehydration flag ONLY if the canonical session-scoped WORKING_CONTEXT was written.
   # A stray .agent/WORKING_CONTEXT.md or project-root WORKING_CONTEXT.md must NOT clear the flag —
   # block-stray-working-context.sh blocks those at PreToolUse, but defend in depth.
-  if [[ "$FILE_PATH" =~ /\.agent/sessions/[^/]+/WORKING_CONTEXT\.md$ ]] && [ -f "$REHYDRATE_FLAG" ]; then
+  # The session component must be OURS. A generic [^/]+ meant that writing any
+  # other session's WORKING_CONTEXT — or a traversal spelling of the path —
+  # cleared this session's flag, so a rehydrate that never happened here looked
+  # like one that did.
+  if [ -f "$REHYDRATE_FLAG" ] \
+     && [[ "$FILE_PATH" =~ (^|/)\.agent/sessions/([^/]+)/WORKING_CONTEXT\.md$ ]] \
+     && { [ "${BASH_REMATCH[2]}" = "$SID_FULL" ] || [ "${BASH_REMATCH[2]}" = "$SID" ]; }; then
     rm -f "$REHYDRATE_FLAG" 2>/dev/null || true
   fi
 
@@ -508,7 +540,7 @@ if [ -f "$UPDATE_APPLIED_FILE" ] && [ -n "${MEGAVIBE_LAUNCH_VERSION:-}" ] && [ "
   NEW_VER=$(cat "$UPDATE_APPLIED_FILE" 2>/dev/null || echo "")
   if [ -n "$NEW_VER" ] && [ "$NEW_VER" != "$MEGAVIBE_LAUNCH_VERSION" ]; then
     # Show once per session (flag in session-scoped dir)
-    SESSION_DIR=".agent/sessions/${SID}"
+    SESSION_DIR=".agent/sessions/${SID_FULL}"
     SEEN_FLAG="${SESSION_DIR}/.update-nudge-seen"
     if [ ! -f "$SEEN_FLAG" ]; then
       mkdir -p "$SESSION_DIR" 2>/dev/null || true

--- a/template/.claude/hooks/log-tool-event.sh
+++ b/template/.claude/hooks/log-tool-event.sh
@@ -130,7 +130,13 @@ fi
 # The cost of that false positive is one skipped nudge, which is why it stands.
 for _wc in ".agent/sessions/${SID_FULL}/WORKING_CONTEXT.md" ".agent/sessions/${SID}/WORKING_CONTEXT.md"; do
   [ -f "$REHYDRATE_FLAG" ] || break
-  if [ -s "$_wc" ] && [ "$_wc" -nt "$REHYDRATE_FLAG" ]; then
+  # NOT `$_wc -nt $FLAG`: -nt is whole-second on the bash 3.2 macOS ships, so a
+  # rehydrate landing in the same second as the flag compared as older. That is
+  # the common case — the flag is set at compaction and /rehydrate runs moments
+  # later — and it produced three false nags then a false auto-clear, plus the
+  # forced Stop turn this whole change exists to remove. Equality means fresh:
+  # on-compact.sh only sets the flag when the WC is over an hour old.
+  if [ -s "$_wc" ] && [ ! "$REHYDRATE_FLAG" -nt "$_wc" ]; then
     rm -f "$REHYDRATE_FLAG" 2>/dev/null || true
   fi
 done

--- a/template/.claude/hooks/on-compact.sh
+++ b/template/.claude/hooks/on-compact.sh
@@ -53,7 +53,22 @@ echo "on-compact.sh fired at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
 
 # Extract session ID for scoping
 SID=$(echo "$INPUT" | jq -r '.session_id // "default"' | cut -c1-12)
-SESSION_DIR=".agent/sessions/${SID}"
+# The sessions DIRECTORY is keyed on the FULL session id, not the 12-char SID
+# used for flat flag files. /rehydrate derives its path from session_id in the
+# hook payload, so truncating here made the hook advertise one directory while
+# the skill wrote another: the stale-context hint read an empty file, and
+# .needs-rehydration never cleared because the file it watches was never the
+# file that got written.
+SID_FULL=$(echo "$INPUT" | jq -r '.session_id // "default"')
+SID_FULL="${SID_FULL:-default}"
+# Validate before it becomes a path component. session_id comes from the harness
+# and is a UUID in practice, but this string is interpolated into mkdir/read
+# targets, and "in practice" is not a boundary. Anything outside a safe charset
+# — or a bare . / .. — falls back to the same "default" the missing-id case uses.
+case "$SID_FULL" in
+  ''|.|..|*[!A-Za-z0-9._-]*) SID_FULL="default" ;;
+esac
+SESSION_DIR=".agent/sessions/${SID_FULL}"
 mkdir -p "$SESSION_DIR"
 
 # Reset augment-search ledgers: compaction drops the just-written / already-seen
@@ -71,6 +86,14 @@ rm -f ".agent/LOGS/injected.${SID}.log" ".agent/LOGS/session-writes.${SID}.log" 
 rm -f ".agent/LOGS/.closeout-done.${SID}"       ".agent/LOGS/.closeout-blocked.${SID}"       ".agent/LOGS/.closeout-count.${SID}"       ".agent/LOGS/.rehydrate-nudge.${SID}"       ".agent/LOGS/.rehydrate-blocked.${SID}" 2>/dev/null || true
 
 WC_PATH="${SESSION_DIR}/WORKING_CONTEXT.md"
+# Read-side migration. A session already running when this fix landed has its
+# context in the old truncated directory, and compaction is exactly the moment
+# that file is worth the most. Reads fall back to it; WC_PATH — the path
+# advertised to Claude as the write target — stays canonical, so the next
+# /rehydrate moves the session forward instead of deepening the split.
+WC_READ="$WC_PATH"
+[ -s "$WC_READ" ] || [ ! -s ".agent/sessions/${SID}/WORKING_CONTEXT.md" ] \
+  || WC_READ=".agent/sessions/${SID}/WORKING_CONTEXT.md"
 INSTRUCTIONS_FILE=".agent/LOGS/rehydration-instructions.${SID}.md"
 
 # WC freshness gate: if /rehydrate ran within the last hour, the existing
@@ -80,8 +103,8 @@ INSTRUCTIONS_FILE=".agent/LOGS/rehydration-instructions.${SID}.md"
 # Claude won't do if it (correctly) decides carryover context is sufficient.
 # Skip the flag in that case; user can still invoke /rehydrate voluntarily.
 WC_FRESH=0
-if [ -f "$WC_PATH" ]; then
-  WC_MTIME=$(stat -f %m "$WC_PATH" 2>/dev/null || stat -c %Y "$WC_PATH" 2>/dev/null || echo 0)
+if [ -f "$WC_READ" ]; then
+  WC_MTIME=$(stat -f %m "$WC_READ" 2>/dev/null || stat -c %Y "$WC_READ" 2>/dev/null || echo 0)
   NOW_TS=$(date +%s)
   WC_AGE=$(( NOW_TS - WC_MTIME ))
   [ "$WC_AGE" -lt 3600 ] 2>/dev/null && WC_FRESH=1
@@ -138,8 +161,8 @@ ${GIT_DIFF_STAT}"
 # a what-was-I-doing hint. Truncate to 40 lines — even at 40 lines this is
 # a stale hint, not authoritative; longer was bloating the systemMessage.
 OLD_WC=""
-if [ -f "$WC_PATH" ]; then
-  OLD_WC_BODY=$(head -40 "$WC_PATH" 2>/dev/null || echo "")
+if [ -f "$WC_READ" ]; then
+  OLD_WC_BODY=$(head -40 "$WC_READ" 2>/dev/null || echo "")
   if [ -n "$OLD_WC_BODY" ]; then
     OLD_WC="--- Pre-compact WORKING_CONTEXT.md (first 40 lines, stale hint only) ---
 ${OLD_WC_BODY}"

--- a/template/.claude/hooks/on-compact.sh
+++ b/template/.claude/hooks/on-compact.sh
@@ -53,6 +53,12 @@ echo "on-compact.sh fired at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
 
 # Extract session ID for scoping
 SID=$(echo "$INPUT" | jq -r '.session_id // "default"' | cut -c1-12)
+# Same gate as SID_FULL. `cut` bounds the LENGTH but not the content: a
+# session_id of "../../../../" survives it intact, and this value is a path
+# component in the flag filenames below.
+case "$SID" in
+  ''|.|..|*[!A-Za-z0-9._-]*) SID="default" ;;
+esac
 # The sessions DIRECTORY is keyed on the FULL session id, not the 12-char SID
 # used for flat flag files. /rehydrate derives its path from session_id in the
 # hook payload, so truncating here made the hook advertise one directory while
@@ -69,7 +75,7 @@ case "$SID_FULL" in
   ''|.|..|*[!A-Za-z0-9._-]*) SID_FULL="default" ;;
 esac
 SESSION_DIR=".agent/sessions/${SID_FULL}"
-mkdir -p "$SESSION_DIR"
+mkdir -p "$SESSION_DIR" 2>/dev/null || true
 
 # Reset augment-search ledgers: compaction drops the just-written / already-seen
 # content out of the live window, so re-injecting it becomes useful again. Without
@@ -182,11 +188,11 @@ echo "FULL_CONTEXT: ${FULL_CONTEXT_SIZE} bytes, ${FULL_CONTEXT_LINES} lines" >&2
 if [ "$FULL_CONTEXT_LINES" -le 10 ]; then
   # === BOOTSTRAP: .agent/ files are empty ===
   echo "Strategy: bootstrap (empty .agent/ files)" >&2
-  [ "$WC_FRESH" -eq 0 ] && touch ".agent/LOGS/.needs-rehydration.${SID}"
+  [ "$WC_FRESH" -eq 0 ] && { touch ".agent/LOGS/.needs-rehydration.${SID}" 2>/dev/null || true; }
 
   CONTEXT="⚠️ CONTEXT WAS JUST COMPACTED — .agent/ FILES ARE EMPTY
 
-Session: ${SID}
+Session: ${SID_FULL}
 WORKING_CONTEXT path: ${WC_PATH}
 
 The .agent/ context files were never populated during this session. The
@@ -222,7 +228,7 @@ elif [ "$FULL_CONTEXT_SIZE" -lt 10240 ]; then
 
   CONTEXT="✅ CONTEXT WAS COMPACTED — orientation below. Your only required action is /rehydrate.
 
-Session: ${SID}
+Session: ${SID_FULL}
 WORKING_CONTEXT path: ${WC_PATH}
 FULL_CONTEXT on disk: .agent/FULL_CONTEXT.md (${FULL_CONTEXT_LINES} lines, ${FULL_CONTEXT_SIZE} bytes — small enough to inline below)
 
@@ -255,7 +261,7 @@ ${FULL_CONTEXT}"
 else
   # === NORMAL: instruct Claude to call Gemini/Codex for focused summary ===
   echo "Strategy: rehydration instructions (${FULL_CONTEXT_SIZE} bytes, ${FULL_CONTEXT_LINES} lines, wc_fresh=${WC_FRESH})" >&2
-  [ "$WC_FRESH" -eq 0 ] && touch ".agent/LOGS/.needs-rehydration.${SID}"
+  [ "$WC_FRESH" -eq 0 ] && { touch ".agent/LOGS/.needs-rehydration.${SID}" 2>/dev/null || true; }
 
   if [ "$WC_FRESH" -eq 1 ]; then
     REHYDRATE_HINT="Your prior WORKING_CONTEXT (${WC_PATH}) was written within the last hour
@@ -271,7 +277,7 @@ so you get a clean window."
 
   CONTEXT="⚠️ CONTEXT WAS JUST COMPACTED
 
-Session: ${SID}
+Session: ${SID_FULL}
 WORKING_CONTEXT path: ${WC_PATH}
 FULL_CONTEXT on disk: .agent/FULL_CONTEXT.md (${FULL_CONTEXT_LINES} lines, ${FULL_CONTEXT_SIZE} bytes — the append-only source of truth, too large to inline)
 Durable backup of these instructions: ${INSTRUCTIONS_FILE}

--- a/template/.claude/hooks/on-session-start.sh
+++ b/template/.claude/hooks/on-session-start.sh
@@ -44,6 +44,12 @@ LESSONS_LINES=$(echo "$LESSONS_LINES" | tr -d ' ')
 
 # Extract session ID
 SID=$(echo "$INPUT" | jq -r '.session_id // "default"' | cut -c1-12)
+# Same gate as SID_FULL. `cut` bounds the LENGTH but not the content: a
+# session_id of "../../../../" survives it intact, and this value is a path
+# component in the flag filenames below.
+case "$SID" in
+  ''|.|..|*[!A-Za-z0-9._-]*) SID="default" ;;
+esac
 # The sessions DIRECTORY is keyed on the FULL session id, not the 12-char SID
 # used for flat flag files. /rehydrate derives its path from session_id in the
 # hook payload, so truncating here made the hook advertise one directory while
@@ -143,7 +149,7 @@ SUBAGENT_STATUS="
 
 CONTEXT="## Megavibe — project knowledge
 
-Your session ID is: ${SID}
+Your session ID is: ${SID_FULL}
 WORKING_CONTEXT path: .agent/sessions/${SID_FULL}/WORKING_CONTEXT.md
 
 ${TASK_HINT}

--- a/template/.claude/hooks/on-session-start.sh
+++ b/template/.claude/hooks/on-session-start.sh
@@ -44,6 +44,21 @@ LESSONS_LINES=$(echo "$LESSONS_LINES" | tr -d ' ')
 
 # Extract session ID
 SID=$(echo "$INPUT" | jq -r '.session_id // "default"' | cut -c1-12)
+# The sessions DIRECTORY is keyed on the FULL session id, not the 12-char SID
+# used for flat flag files. /rehydrate derives its path from session_id in the
+# hook payload, so truncating here made the hook advertise one directory while
+# the skill wrote another: the stale-context hint read an empty file, and
+# .needs-rehydration never cleared because the file it watches was never the
+# file that got written.
+SID_FULL=$(echo "$INPUT" | jq -r '.session_id // "default"')
+SID_FULL="${SID_FULL:-default}"
+# Validate before it becomes a path component. session_id comes from the harness
+# and is a UUID in practice, but this string is interpolated into mkdir/read
+# targets, and "in practice" is not a boundary. Anything outside a safe charset
+# — or a bare . / .. — falls back to the same "default" the missing-id case uses.
+case "$SID_FULL" in
+  ''|.|..|*[!A-Za-z0-9._-]*) SID_FULL="default" ;;
+esac
 
 # Check for open tasks to tailor the message
 OPEN_TASKS=$(grep -cE "\| pending|\| in.progress" ".agent/TASKS.md" 2>/dev/null || echo "0")
@@ -129,7 +144,7 @@ SUBAGENT_STATUS="
 CONTEXT="## Megavibe — project knowledge
 
 Your session ID is: ${SID}
-WORKING_CONTEXT path: .agent/sessions/${SID}/WORKING_CONTEXT.md
+WORKING_CONTEXT path: .agent/sessions/${SID_FULL}/WORKING_CONTEXT.md
 
 ${TASK_HINT}
 ${SUBAGENT_STATUS}


### PR DESCRIPTION
## Bug

Hooks derived `.agent/sessions/<id>/` from `session_id | cut -c1-12`. The `/rehydrate` skill derives it from the full `session_id`. Two components built the same path from the same input by different rules, so nothing ever errored — one side just wrote a file the other never read.

**Observed, live in this session:**

1. `.needs-rehydration.<12char>` never cleared when `/rehydrate` wrote via the Bash redirect its own skill prescribes — `log-tool-event.sh` mtime-compared the truncated path, which the skill never writes. Harmless until #13 put a `Stop` hook on that flag; then it cost a forced turn on every compaction. Found by running that loop for real, one turn after a manual compaction.
2. `on-compact.sh` read its pre-compact stale hint from the truncated directory — a nonexistent file for every session that followed the skill. The empty 12-char directories under `.agent/sessions/` are the fossil record.

**Repro:** in a megavibe project, `touch .agent/LOGS/.needs-rehydration.$(echo $SID | cut -c1-12)`, write `.agent/sessions/$SID/WORKING_CONTEXT.md` with a Bash redirect, fire any tool call. Before this change the flag survives; it should clear.

## Fix

The **directory** moves to the full `session_id`. Flat flag and counter **filenames** keep the 12-char SID — renaming those mid-session would orphan every live flag, and a filename namespace has different needs from a path component both sides construct independently.

Three reviewers (reviewer subagent + Gemini + Codex). Codex returned DO-NOT-SHIP twice and found five more, four older than this change and all in code it already touched:

| # | Issue | Fix |
|---|---|---|
| 1 | `block-stray-working-context.sh` exited 2 **outside any megavibe project** — invariant 3 licenses only `block-dangerous-bash.sh` and `rm-to-trash.sh` for that | added the `.agent` guard |
| 2 | Its `[^/]+` session pattern matched `..`, so `.agent/sessions/../WORKING_CONTEXT.md` — which resolves to exactly the stray path the hook rejects — was waved through by the pattern meant to catch it | `.` / `..` rejected explicitly |
| 3 | The same pattern required a leading `/`, so the **relative** canonical path the hook advertises in its own suggestion was blocked | `(^\|/)` boundary |
| 4 | `log-tool-event.sh`'s Write branch used that loose pattern too: writing **any** session's WORKING_CONTEXT cleared **this** session's flag | captured component must equal `SID_FULL` or `SID` |
| 5 | `session_id` went unvalidated into `mkdir -p` | gated to `[A-Za-z0-9._-]`, `.`/`..` rejected, else `default` |
| 6 | `on-compact.sh` had no read-side migration, so a session upgraded mid-flight lost its context at the boundary where it is worth most | `WC_READ` falls back to the legacy path for the freshness gate and stale hint; `WC_PATH`, the advertised write target, stays canonical so the next `/rehydrate` moves the session forward instead of deepening the split |

**Knowingly kept**, now stated in the code rather than implied away: the 12-char flag namespace collides for two sessions sharing a UUID prefix (negligible, pre-existing), and clearing on "newer than the flag" proves mtime, not authorship — an unrelated touch satisfies it, at a cost of one skipped nudge. The previous comment claimed a scoping guarantee that does not exist.

**Verified** — 24 end-to-end tests against the hooks in a throwaway `init.sh` project: flag clears on the full and legacy paths, survives with no WORKING_CONTEXT, with a stale one, and on another session's write; every canonical spelling (relative, `./`, absolute) allowed and every stray and traversal spelling blocked; a malicious `session_id` lands in `sessions/default` rather than escaping `.agent`; `on-compact` recovers a legacy hint while advertising the full path. `bash -n` clean on all four, `template/` and live `.claude/` in sync.

https://claude.ai/code/session_0198Zf65uR4fiFZ9bmHDqLsJ