### PR TITLE
hooks: heal legacy user-level hooks without deleting the user's own

### DIFF
--- a/megavibe
+++ b/megavibe
@@ -965,11 +965,12 @@ LEGACY_DEF='
   # The lookahead keeps $CLAUDE_PROJECT_DIR_BACKUP — a DIFFERENT variable that
   # can point anywhere — from being rewritten to /__project___BACKUP and
   # inheriting the exemption.
-  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?(?![A-Za-z0-9_])"; "/__project__");
-  def in_hookdir: norm as $c
-    | at_boundary($c; $home + "/.claude/hooks/")
-      or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
-      or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
+  def nstr: gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?(?![A-Za-z0-9_])"; "/__project__");
+  def norm: cmd | nstr;
+  def in_hookdir_s($c): at_boundary($c; $home + "/.claude/hooks/")
+    or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
+    or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
+  def in_hookdir: in_hookdir_s(norm);
   # One occurrence must satisfy BOTH halves: the text before it has to be a
   # user-level hooks-dir prefix, the text after it a shell terminator or the
   # end of the string. Testing the two halves independently deleted
@@ -979,8 +980,8 @@ LEGACY_DEF='
   #
   # The expanded-$HOME prefix carries the same boundary requirement as every
   # other spelling: a bare endswith() deleted
-  # "/opt/mirror/Users/alice/.claude/hooks/agent-log.sh", a MIRROR of the
-  # user home under another root, which is a different directory entirely.
+  # "/opt/mirror$HOME/.claude/hooks/agent-log.sh", a MIRROR of the user home
+  # under another root, which is a different directory entirely.
   #
   # Residual, accepted: a user hook that passes one of OUR paths as an
   # argument ("mine.sh --fallback ~/.claude/hooks/agent-log.sh") still reads
@@ -1008,21 +1009,45 @@ LEGACY_DEF='
   # An occurrence is exempt only when its own prefix ends in an absolute path
   # token — unquoted and space-free, or quoted and then free to contain
   # spaces. Anything it cannot resolve blocks the archive: fail closed.
+  # Third alternative: "$HOME/dev/myproj/.claude/hooks/notify.sh" is an
+  # ordinary user-level registration of a PROJECT hook, and only the absolute
+  # spelling of it was exempt — so the $HOME spelling blocked the archive on
+  # every run forever, under a message telling the user to delete a
+  # registration that is doing its job. It needs at least one segment between
+  # $HOME and .claude/, so "$HOME/.claude/hooks/" — our own dir — still
+  # blocks (and in_hookdir catches that one first regardless).
   def other_checkout: test("(^|[ \t\r\n\"\u0027;|&(])/[^ \t\r\n\"\u0027;|&()]*$")
-    or test("(^|[ \t\r\n;|&(])[\"\u0027]/[^\"\u0027]*$");
-  def references_hookdir: norm as $c
-    | ($c | contains(".claude/hooks/"))
-      and (in_hookdir
-           or (($c | split(".claude/hooks/")) as $p
-               | any($p[0:-1][]; other_checkout | not)));
+    or test("(^|[ \t\r\n;|&(])[\"\u0027]/[^\"\u0027]*$")
+    or test("(^|[ \t\r\n\"\u0027;|&(])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/[^ \t\r\n\"\u0027;|&()]+/$");
+  def refs_s($c): ($c | contains(".claude/hooks/"))
+    and (in_hookdir_s($c)
+         or (($c | split(".claude/hooks/")) as $p
+             | any($p[0:-1][]; other_checkout | not)));
+  def references_hookdir: refs_s(norm);
+  # The pre-archive scan runs over every STRING in the document, not over
+  # .hooks entries. statusLine.command and apiKeyHelper point at a script the
+  # same way a hook does, and scoping the gate to .hooks archived the
+  # directory out from under them while printing "archived legacy hook
+  # scripts" — exactly the outcome this gate exists to prevent. Scanning
+  # strings also covers command keys that do not exist yet.
+  def references_hookdir_str: refs_s(nstr);
 '
 heal_legacy_hooks() {
-  local f="$1" found stamp
+  local f="$1" found stamp n_legacy cmds_legacy
   [ -f "$f" ] || return 0
+  # The detection pass also CARRIES the commands it matched, so the success
+  # line can name them. A removal the user disagrees with (their own script
+  # whose basename collides with one of the 29, or a command that merely
+  # mentions a hook path) is otherwise silent, and the backup they would need
+  # is only findable if they know something was taken.
   found=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" "$LEGACY_DEF"'
-      [ .hooks? // {} | .. | objects | select(legacy) ] | length > 0
-    ' "$f" 2>/dev/null || echo false)
-  [ "$found" = "true" ] || return 0
+      [ .hooks? // {} | .. | objects | select(legacy) | cmd ] as $c
+      | "\($c | length)\n\($c[0:3] | map(gsub("\\s+"; " ")) | join("; "))"
+    ' "$f" 2>/dev/null || printf "0\n")
+  n_legacy=$(printf '%s' "$found" | sed -n 1p)
+  cmds_legacy=$(printf '%s' "$found" | sed -n 2p)
+  case "$n_legacy" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$n_legacy" -gt 0 ] || return 0
   # Cleared BEFORE the redirect, not only after: a leftover settings.json.tmp
   # that is a SYMLINK makes the redirect write through it into whatever it
   # points at, and one that is a DIRECTORY makes the redirect fail. Neither is
@@ -1077,7 +1102,7 @@ heal_legacy_hooks() {
       rm -rf "${f}.tmp" 2>/dev/null || true
       return 0
     fi
-    echo "  Healed: removed legacy ~/.claude/hooks/ entries from $(basename "$f") (they double-fired against project hooks; backup: $(basename "$f").pre-hookclean-${stamp})."
+    echo "  Healed: removed ${n_legacy} legacy ~/.claude/hooks/ registration(s) from $(basename "$f") — ${cmds_legacy} (they double-fired against project hooks; backup: $(basename "$f").pre-hookclean-${stamp})."
   else
     echo "  Note: $(basename "$f") has legacy ~/.claude/hooks/ registrations that could not be rewritten — left untouched."
   fi
@@ -1094,7 +1119,7 @@ if [ -d "$LEGACY_USER_HOOKS" ]; then
     for f in "${LEGACY_SETTINGS_FILES[@]}"; do
       [ -f "$f" ] || continue
       REF=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" --arg file "$(basename "$f")" "$LEGACY_DEF"'
-          [ .hooks? // {} | .. | objects | select(references_hookdir) | cmd ] as $c
+          [ .. | strings | select(references_hookdir_str) ] as $c
           | if ($c | length) == 0 then "0"
             else "\($c | length) in \($file): \($c[0:2] | join("; "))"
             end

--- a/megavibe
+++ b/megavibe
@@ -928,44 +928,173 @@ if [ -f "$TPL_STATUSLINE" ] && [ -f "$ACTIVE_STATUSLINE" ] \
   echo "  Statusline updated."
 fi
 
-# Auto-heal legacy USER-LEVEL hooks (setup.sh has the same cleanup, but it
-# only runs when the pre-flight above re-triggers setup — a machine set up
+# Auto-heal legacy USER-LEVEL hooks (setup.sh has the same cleanup in §5b, but
+# it only runs when the pre-flight above re-triggers setup — a machine set up
 # before the cleanup landed never healed). Hooks are project-level since the
 # layout change; a stale .hooks block in ~/.claude/settings.json pointing at
 # ~/.claude/hooks/ makes every hook fire TWICE (observed: poma-memory context
-# injected 2x per search). Surgical, unlike setup.sh's del(.hooks): only
-# entries whose command references ~/.claude/hooks/ are removed, so hooks the
-# user deliberately added at user level (other paths) survive. The script dir
-# is archived, never deleted. Runs pre-claude — no live session loses hooks
+# injected 2x per search). Runs pre-claude — no live session loses hooks
 # mid-flight. Idempotent: nothing legacy → no-op, no output.
-USER_SETTINGS_HEAL="$HOME/.claude/settings.json"
+#
+# This is setup.sh §5b's logic, deliberately duplicated: setup.sh bootstraps
+# the machine this wrapper lives on, so there is no shared library to put it
+# in. The comments explaining WHY each piece is shaped this way live there.
+# Edit both or neither. In short: removal needs BOTH a reference to the
+# user-level hooks dir AND a basename megavibe itself ships, so a script the
+# user parked there survives; matching is boundary-anchored so
+# /opt/my~/.claude/hooks/x and $CLAUDE_PROJECT_DIR/.claude/hooks/x survive;
+# settings.local.json is scanned too; and the directory is never archived
+# while anything still points into it.
 LEGACY_USER_HOOKS="$HOME/.claude/hooks"
-if command -v jq &>/dev/null && [ -f "$USER_SETTINGS_HEAL" ] \
-   && jq -e --arg d "$LEGACY_USER_HOOKS/" \
-        '[.hooks // {} | .. | objects | select(.type? == "command") | .command // "" | select(contains($d))] | length > 0' \
-        "$USER_SETTINGS_HEAL" >/dev/null 2>&1; then
-  jq --arg d "$LEGACY_USER_HOOKS/" '
-    .hooks |= (
-      with_entries(
-        .value |= map(
-          .hooks |= map(select((.command // "" | contains($d)) | not))
-        ) | .value |= map(select(.hooks | length > 0))
-      ) | with_entries(select(.value | length > 0))
-    ) | if .hooks == {} then del(.hooks) else . end
-  ' "$USER_SETTINGS_HEAL" > "${USER_SETTINGS_HEAL}.tmp" \
-    && jq -e . "${USER_SETTINGS_HEAL}.tmp" >/dev/null 2>&1 \
-    && mv "${USER_SETTINGS_HEAL}.tmp" "$USER_SETTINGS_HEAL"
-  rm -f "${USER_SETTINGS_HEAL}.tmp"
-  echo "  Healed: removed legacy ~/.claude/hooks/ entries from user settings (they double-fired against project hooks)."
+LEGACY_HOOK_NAMES='["after-edit.sh","agent-log.sh","augment-search.sh","block-dangerous-bash.sh","block-plan-mode.sh","block-stray-working-context.sh","codex-approval-never.sh","compaction-autopilot.sh","enforce-pr-format.sh","kube-token.sh","log-tool-event.sh","nudge-native-tools.sh","nudge-quiet-bash.sh","nudge-restart.sh","on-compact.sh","on-pre-compact.sh","on-session-end.sh","on-session-start.sh","read-delta.sh","redact-secrets.sh","reindex-agent.sh","resize-image.sh","revive-watcher.sh","rm-to-trash.sh","session-start.sh","snapshot.sh","start-context-watcher.sh","start-poma-serve.sh","truncate-verbose-bash.sh"]'
+LEGACY_DEF='
+  def cmd: .command | if type == "string" then . else "" end;
+  # $CLAUDE_PROJECT_DIR is neutralised, not excluded. A blanket
+  # contains("CLAUDE_PROJECT_DIR") test let ANY command mentioning it past the
+  # archive gate — including "$HOME/.claude/hooks/notify.sh \"$CLAUDE_PROJECT_DIR\"",
+  # an ordinary thing to write — and the dir was then archived out from under
+  # a live registration, reported as a heal. Rewritten to an absolute token it
+  # keeps $CLAUDE_PROJECT_DIR/.claude/hooks/x.sh non-blocking on its own merits.
+  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?"; "/__project__");
+  def in_hookdir: norm as $c
+    | ($c | contains($home + "/.claude/hooks/"))
+      or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
+      or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
+  # One occurrence must satisfy BOTH halves: the text before it has to be a
+  # user-level hooks-dir prefix, the text after it a shell terminator or the
+  # end of the string. Testing the two halves independently deleted
+  # "~/.claude/hooks/mine.sh /opt/other/.claude/hooks/log-tool-event.sh" —
+  # in_hookdir from the first path, ours from the second. split() rather than
+  # a regex so the 29 names need no escaping.
+  #
+  # Residual, accepted: a user hook that passes one of OUR paths as an
+  # argument ("mine.sh --fallback ~/.claude/hooks/agent-log.sh") still reads
+  # as legacy. Separating that from "bash ~/.claude/hooks/agent-log.sh" needs
+  # to know which token is the command, i.e. an interpreter list, which is
+  # more machinery than a bootstrapper should carry. The backup written before
+  # the rewrite is the recovery path.
+  def legacy: norm as $c
+    | any($names[];
+        (".claude/hooks/" + .) as $needle
+        | ($c | split($needle)) as $parts
+        | ($parts | length) > 1
+          and any(range(0; ($parts | length) - 1);
+                . as $i
+                | ($parts[$i+1] | . == "" or (.[0:1] | test("[ \t\r\n\"\u0027;|&<>,)]")))
+                  and ($parts[$i]
+                       | . == ""
+                         or endswith($home + "/")
+                         or test("(^|[ \t\"\u0027;|&(])((\\$HOME|\\$\\{HOME\\}|\"\\$HOME\"|~|\\.)/)?$"))));
+  def references_hookdir: norm as $c
+    | ($c | contains(".claude/hooks/"))
+      and (in_hookdir or ($c | test("(^|[ \t\"\u0027])/[^ \t\"\u0027]*\\.claude/hooks/") | not));
+'
+heal_legacy_hooks() {
+  local f="$1" found stamp
+  [ -f "$f" ] || return 0
+  found=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" "$LEGACY_DEF"'
+      [ .hooks? // {} | .. | objects | select(legacy) ] | length > 0
+    ' "$f" 2>/dev/null || echo false)
+  [ "$found" = "true" ] || return 0
+  # Braced so the SHELL's own redirect failure (read-only ~/.claude) is caught
+  # too, not just jq's stderr — otherwise a raw "Permission denied" line lands
+  # in front of the launcher's own message.
+  if { jq --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" "$LEGACY_DEF"'
+        if (.hooks | type) != "object" then .
+        else
+          .hooks |= (
+            with_entries(
+              .value |= (
+                if type != "array" then .
+                else map(
+                  if type != "object" then .
+                  elif (.hooks | type) == "array"
+                  then (.hooks |= map(select(if type == "object" then legacy | not else true end)))
+                       | select((.hooks | length) > 0)
+                  elif legacy then empty
+                  else .
+                  end
+                )
+                end
+              )
+            )
+            | with_entries(select((.value | type) != "array" or (.value | length) > 0))
+          )
+          | if .hooks == {} then del(.hooks) else . end
+        end
+      ' "$f" > "${f}.tmp"; } 2>/dev/null \
+     && jq -e . "${f}.tmp" >/dev/null 2>&1 \
+     && ! jq -e --slurpfile new "${f}.tmp" '. == $new[0]' "$f" >/dev/null 2>&1; then
+    stamp=$(date +%Y%m%d-%H%M%S)
+    # If the backup cannot be written, nothing is rewritten. It is the only
+    # copy of the removed registrations — .megavibe-backup is overwritten on
+    # every setup run — so announcing a backup path that does not exist while
+    # discarding the original is the one outcome to rule out.
+    if ! cp "$f" "${f}.pre-hookclean-${stamp}" 2>/dev/null; then
+      echo "  Note: could not back up $(basename "$f") — left untouched."
+      rm -rf "${f}.tmp" 2>/dev/null || true
+      return 0
+    fi
+    # cp, not mv, and a guarded one. mv replaces a symlinked settings.json
+    # with a regular file, stranding the dotfiles copy it pointed at, and
+    # drops the file mode; and an mv that fails (immutable flag, ACL, a sync
+    # mount) exits the whole script under set -e — in the launcher that means
+    # claude never starts, with a fresh backup left behind on every attempt.
+    if ! cp "${f}.tmp" "$f" 2>/dev/null; then
+      echo "  Note: could not rewrite $(basename "$f") — left untouched."
+      rm -rf "${f}.tmp" "${f}.pre-hookclean-${stamp}" 2>/dev/null || true
+      return 0
+    fi
+    echo "  Healed: removed legacy ~/.claude/hooks/ entries from $(basename "$f") (they double-fired against project hooks; backup: $(basename "$f").pre-hookclean-${stamp})."
+  else
+    echo "  Note: $(basename "$f") has legacy ~/.claude/hooks/ registrations that could not be rewritten — left untouched."
+  fi
+  rm -rf "${f}.tmp" 2>/dev/null || true
+}
+LEGACY_SETTINGS_FILES=("$HOME/.claude/settings.json" "$HOME/.claude/settings.local.json")
+if command -v jq &>/dev/null; then
+  for f in "${LEGACY_SETTINGS_FILES[@]}"; do heal_legacy_hooks "$f"; done
 fi
 if [ -d "$LEGACY_USER_HOOKS" ]; then
-  HOOKS_ARCHIVE="${LEGACY_USER_HOOKS}.legacy-$(date +%Y%m%d)"
-  if [ ! -e "$HOOKS_ARCHIVE" ]; then
-    mv "$LEGACY_USER_HOOKS" "$HOOKS_ARCHIVE"
-    echo "  Healed: archived legacy ~/.claude/hooks/ to ${HOOKS_ARCHIVE}/."
+  STILL_REFERENCED=0
+  if command -v jq &>/dev/null; then
+    for f in "${LEGACY_SETTINGS_FILES[@]}"; do
+      [ -f "$f" ] || continue
+      REF=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" --arg file "$(basename "$f")" "$LEGACY_DEF"'
+          [ .hooks? // {} | .. | objects | select(references_hookdir) | cmd ] as $c
+          | if ($c | length) == 0 then "0"
+            else "\($c | length) in \($file): \($c[0:2] | join("; "))"
+            end
+        ' "$f" 2>/dev/null || echo "?")
+      [ "$REF" = "0" ] || STILL_REFERENCED="$REF"
+    done
   else
-    rm -rf "$LEGACY_USER_HOOKS"
-    echo "  Healed: removed legacy ~/.claude/hooks/ (archive ${HOOKS_ARCHIVE}/ already exists)."
+    STILL_REFERENCED="?"
+  fi
+  # Said ONCE, then never again. The launcher runs on every invocation, so a
+  # note repeated per session is noise the user cannot silence without
+  # deleting a working hook. Saying nothing at all is worse: this is also the
+  # state where a pre-repo hook name nobody has on record keeps double-firing,
+  # and the old launcher at least healed that case blindly. One line, one
+  # stamp file, and setup.sh repeats it where runs are rare.
+  if [ "$STILL_REFERENCED" = "?" ] || [ "$STILL_REFERENCED" != "0" ]; then
+    if [ ! -e "$HOME/.claude/.megavibe-hookdir-noted" ]; then
+      if [ "$STILL_REFERENCED" = "?" ]; then
+        echo "  Note: left ~/.claude/hooks/ in place — could not check ~/.claude settings for registrations pointing into it."
+      else
+        echo "  Note: left ~/.claude/hooks/ in place — still referenced by ${STILL_REFERENCED}. If that is not yours, it is firing twice; remove it from ~/.claude/settings.json."
+      fi
+      touch "$HOME/.claude/.megavibe-hookdir-noted" 2>/dev/null || true
+    fi
+  else
+    HOOKS_ARCHIVE="${LEGACY_USER_HOOKS}.legacy-$(date +%Y%m%d)"
+    [ -e "$HOOKS_ARCHIVE" ] && HOOKS_ARCHIVE="${LEGACY_USER_HOOKS}.legacy-$(date +%Y%m%d-%H%M%S)"
+    if [ ! -e "$HOOKS_ARCHIVE" ]; then
+      mv "$LEGACY_USER_HOOKS" "$HOOKS_ARCHIVE"
+      echo "  Healed: archived legacy ~/.claude/hooks/ to ${HOOKS_ARCHIVE}/."
+    else
+      echo "  Note: left ~/.claude/hooks/ in place — ${HOOKS_ARCHIVE}/ already exists."
+    fi
   fi
 fi
 

--- a/megavibe
+++ b/megavibe
@@ -949,15 +949,25 @@ LEGACY_USER_HOOKS="$HOME/.claude/hooks"
 LEGACY_HOOK_NAMES='["after-edit.sh","agent-log.sh","augment-search.sh","block-dangerous-bash.sh","block-plan-mode.sh","block-stray-working-context.sh","codex-approval-never.sh","compaction-autopilot.sh","enforce-pr-format.sh","kube-token.sh","log-tool-event.sh","nudge-native-tools.sh","nudge-quiet-bash.sh","nudge-restart.sh","on-compact.sh","on-pre-compact.sh","on-session-end.sh","on-session-start.sh","read-delta.sh","redact-secrets.sh","reindex-agent.sh","resize-image.sh","revive-watcher.sh","rm-to-trash.sh","session-start.sh","snapshot.sh","start-context-watcher.sh","start-poma-serve.sh","truncate-verbose-bash.sh"]'
 LEGACY_DEF='
   def cmd: .command | if type == "string" then . else "" end;
+  # A path token in a shell command starts at the string start or after one of
+  # these. Used as the left boundary everywhere, so no predicate can match a
+  # path that merely CONTAINS ours as a substring.
+  def bnd: . == "" or (.[-1:] | test("[ \t\r\n\"\u0027;|&(]"));
+  def at_boundary($c; $needle):
+    ($c | split($needle)) as $p
+    | ($p | length) > 1 and any($p[0:-1][]; bnd);
   # $CLAUDE_PROJECT_DIR is neutralised, not excluded. A blanket
   # contains("CLAUDE_PROJECT_DIR") test let ANY command mentioning it past the
   # archive gate — including "$HOME/.claude/hooks/notify.sh \"$CLAUDE_PROJECT_DIR\"",
   # an ordinary thing to write — and the dir was then archived out from under
   # a live registration, reported as a heal. Rewritten to an absolute token it
   # keeps $CLAUDE_PROJECT_DIR/.claude/hooks/x.sh non-blocking on its own merits.
-  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?"; "/__project__");
+  # The lookahead keeps $CLAUDE_PROJECT_DIR_BACKUP — a DIFFERENT variable that
+  # can point anywhere — from being rewritten to /__project___BACKUP and
+  # inheriting the exemption.
+  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?(?![A-Za-z0-9_])"; "/__project__");
   def in_hookdir: norm as $c
-    | ($c | contains($home + "/.claude/hooks/"))
+    | at_boundary($c; $home + "/.claude/hooks/")
       or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
       or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
   # One occurrence must satisfy BOTH halves: the text before it has to be a
@@ -966,6 +976,11 @@ LEGACY_DEF='
   # "~/.claude/hooks/mine.sh /opt/other/.claude/hooks/log-tool-event.sh" —
   # in_hookdir from the first path, ours from the second. split() rather than
   # a regex so the 29 names need no escaping.
+  #
+  # The expanded-$HOME prefix carries the same boundary requirement as every
+  # other spelling: a bare endswith() deleted
+  # "/opt/mirror/Users/alice/.claude/hooks/agent-log.sh", a MIRROR of the
+  # user home under another root, which is a different directory entirely.
   #
   # Residual, accepted: a user hook that passes one of OUR paths as an
   # argument ("mine.sh --fallback ~/.claude/hooks/agent-log.sh") still reads
@@ -980,14 +995,26 @@ LEGACY_DEF='
         | ($parts | length) > 1
           and any(range(0; ($parts | length) - 1);
                 . as $i
-                | ($parts[$i+1] | . == "" or (.[0:1] | test("[ \t\r\n\"\u0027;|&<>,)]")))
+                | ($parts[$i+1] | . == "" or (.[0:1] | test("[ \t\r\n\"\u0027;|&<>)]")))
                   and ($parts[$i]
-                       | . == ""
-                         or endswith($home + "/")
-                         or test("(^|[ \t\"\u0027;|&(])((\\$HOME|\\$\\{HOME\\}|\"\\$HOME\"|~|\\.)/)?$"))));
+                       | (endswith($home + "/")
+                          and (.[0:(length - ($home | length) - 1)] | bnd))
+                         or test("(^|[ \t\r\n\"\u0027;|&(])(\"?(\\$HOME|\\$\\{HOME\\}|~|\\.)\"?/)?$"))));
+  # Broader than the removal filter, and evaluated PER OCCURRENCE. Deciding it
+  # over the whole string let one unrelated absolute path cancel the
+  # protection for a live reference beside it:
+  # "${HOOK_ROOT}/.claude/hooks/notify.sh /opt/project/.claude/hooks/other.sh"
+  # read as exempt and the directory was archived out from under notify.sh.
+  # An occurrence is exempt only when its own prefix ends in an absolute path
+  # token — unquoted and space-free, or quoted and then free to contain
+  # spaces. Anything it cannot resolve blocks the archive: fail closed.
+  def other_checkout: test("(^|[ \t\r\n\"\u0027;|&(])/[^ \t\r\n\"\u0027;|&()]*$")
+    or test("(^|[ \t\r\n;|&(])[\"\u0027]/[^\"\u0027]*$");
   def references_hookdir: norm as $c
     | ($c | contains(".claude/hooks/"))
-      and (in_hookdir or ($c | test("(^|[ \t\"\u0027])/[^ \t\"\u0027]*\\.claude/hooks/") | not));
+      and (in_hookdir
+           or (($c | split(".claude/hooks/")) as $p
+               | any($p[0:-1][]; other_checkout | not)));
 '
 heal_legacy_hooks() {
   local f="$1" found stamp
@@ -996,6 +1023,11 @@ heal_legacy_hooks() {
       [ .hooks? // {} | .. | objects | select(legacy) ] | length > 0
     ' "$f" 2>/dev/null || echo false)
   [ "$found" = "true" ] || return 0
+  # Cleared BEFORE the redirect, not only after: a leftover settings.json.tmp
+  # that is a SYMLINK makes the redirect write through it into whatever it
+  # points at, and one that is a DIRECTORY makes the redirect fail. Neither is
+  # hypothetical after a killed run or a file-sync client.
+  rm -rf "${f}.tmp" 2>/dev/null || true
   # Braced so the SHELL's own redirect failure (read-only ~/.claude) is caught
   # too, not just jq's stderr — otherwise a raw "Permission denied" line lands
   # in front of the launcher's own message.
@@ -1041,8 +1073,8 @@ heal_legacy_hooks() {
     # mount) exits the whole script under set -e — in the launcher that means
     # claude never starts, with a fresh backup left behind on every attempt.
     if ! cp "${f}.tmp" "$f" 2>/dev/null; then
-      echo "  Note: could not rewrite $(basename "$f") — left untouched."
-      rm -rf "${f}.tmp" "${f}.pre-hookclean-${stamp}" 2>/dev/null || true
+      echo "  Note: could not rewrite $(basename "$f") — backup kept at $(basename "$f").pre-hookclean-${stamp}."
+      rm -rf "${f}.tmp" 2>/dev/null || true
       return 0
     fi
     echo "  Healed: removed legacy ~/.claude/hooks/ entries from $(basename "$f") (they double-fired against project hooks; backup: $(basename "$f").pre-hookclean-${stamp})."
@@ -1057,6 +1089,7 @@ if command -v jq &>/dev/null; then
 fi
 if [ -d "$LEGACY_USER_HOOKS" ]; then
   STILL_REFERENCED=0
+  CHECK_FAILED=0
   if command -v jq &>/dev/null; then
     for f in "${LEGACY_SETTINGS_FILES[@]}"; do
       [ -f "$f" ] || continue
@@ -1066,10 +1099,18 @@ if [ -d "$LEGACY_USER_HOOKS" ]; then
             else "\($c | length) in \($file): \($c[0:2] | join("; "))"
             end
         ' "$f" 2>/dev/null || echo "?")
-      [ "$REF" = "0" ] || STILL_REFERENCED="$REF"
+      # Accumulated, not overwritten. With a reference in settings.json AND
+      # one in settings.local.json, the second assignment used to hide the
+      # first and the user fixed half the problem.
+      if [ "$REF" = "?" ]; then
+        CHECK_FAILED=1
+      elif [ "$REF" != "0" ]; then
+        if [ "$STILL_REFERENCED" = "0" ]; then STILL_REFERENCED="$REF"
+        else STILL_REFERENCED="${STILL_REFERENCED}; ${REF}"; fi
+      fi
     done
   else
-    STILL_REFERENCED="?"
+    CHECK_FAILED=1
   fi
   # Said ONCE, then never again. The launcher runs on every invocation, so a
   # note repeated per session is noise the user cannot silence without
@@ -1077,9 +1118,9 @@ if [ -d "$LEGACY_USER_HOOKS" ]; then
   # state where a pre-repo hook name nobody has on record keeps double-firing,
   # and the old launcher at least healed that case blindly. One line, one
   # stamp file, and setup.sh repeats it where runs are rare.
-  if [ "$STILL_REFERENCED" = "?" ] || [ "$STILL_REFERENCED" != "0" ]; then
+  if [ "$CHECK_FAILED" = "1" ] || [ "$STILL_REFERENCED" != "0" ]; then
     if [ ! -e "$HOME/.claude/.megavibe-hookdir-noted" ]; then
-      if [ "$STILL_REFERENCED" = "?" ]; then
+      if [ "$CHECK_FAILED" = "1" ]; then
         echo "  Note: left ~/.claude/hooks/ in place — could not check ~/.claude settings for registrations pointing into it."
       else
         echo "  Note: left ~/.claude/hooks/ in place — still referenced by ${STILL_REFERENCED}. If that is not yours, it is firing twice; remove it from ~/.claude/settings.json."
@@ -1090,8 +1131,11 @@ if [ -d "$LEGACY_USER_HOOKS" ]; then
     HOOKS_ARCHIVE="${LEGACY_USER_HOOKS}.legacy-$(date +%Y%m%d)"
     [ -e "$HOOKS_ARCHIVE" ] && HOOKS_ARCHIVE="${LEGACY_USER_HOOKS}.legacy-$(date +%Y%m%d-%H%M%S)"
     if [ ! -e "$HOOKS_ARCHIVE" ]; then
-      mv "$LEGACY_USER_HOOKS" "$HOOKS_ARCHIVE"
-      echo "  Healed: archived legacy ~/.claude/hooks/ to ${HOOKS_ARCHIVE}/."
+      if mv "$LEGACY_USER_HOOKS" "$HOOKS_ARCHIVE" 2>/dev/null; then
+        echo "  Healed: archived legacy ~/.claude/hooks/ to ${HOOKS_ARCHIVE}/."
+      else
+        echo "  Note: left ~/.claude/hooks/ in place — could not move it to ${HOOKS_ARCHIVE}/."
+      fi
     else
       echo "  Note: left ~/.claude/hooks/ in place — ${HOOKS_ARCHIVE}/ already exists."
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -885,26 +885,226 @@ fi
 # JSONL bloats, counter nudges fire at half the intended threshold,
 # /compact recovery runs twice, statusMessage redraws double in scrollback.
 #
-# Strip the .hooks key from ~/.claude/settings.json if present, and
-# archive ~/.claude/hooks/ to ~/.claude/hooks.legacy-YYYYMMDD/ (don't
-# delete — preserve any user customizations). Idempotent: re-runs find
-# nothing to clean, skip silently.
+# Two conditions, both required, and the second is what keeps this honest:
+# the command must reference the user-level hooks dir, AND its basename must
+# be a hook megavibe has itself shipped. Path alone would delete a script the
+# user parked in that directory themselves; basename alone would delete a
+# project-scoped registration of the same hook, which is the one that should
+# survive. Anything else pointing into that dir is reported, never removed.
+#
+# LEGACY_HOOK_NAMES is a HISTORICAL list — every hook filename this repo has
+# ever shipped, retired ones included. It does not need updating when a hook
+# is added: new hooks are registered per-project, never at user level, so a
+# name that never existed before 2026-04 cannot appear in a legacy block.
+#
+# A registration can spell the dir several ways and all of them must match.
+# The wrapper matched only the expanded path, so it missed "$HOME/.claude/
+# hooks/..." — the spelling actually observed in the wild — which was only
+# ever removed by the del(.hooks) this replaces. Also matched: ${HOME}/, ~/,
+# the quoted "$HOME"/ form, and a relative .claude/hooks/... at any shell
+# token boundary (what this project's own template emits; in USER scope it
+# resolves against whatever project is cwd, which IS the double-fire).
+#
+# Matching is boundary-anchored, not plain substring: /opt/my~/.claude/hooks/x
+# is a different path and must survive, and $CLAUDE_PROJECT_DIR/.claude/hooks/
+# is a legitimate project-scoped registration.
+#
+# The rewrite is gated on a detection pass, not on "did the file change".
+# Without the gate, a settings.json holding an empty .hooks / an empty event
+# array gets rewritten and announced as a legacy cleanup that removed nothing.
+# Both user-level settings files are scanned: Claude Code reads hooks from
+# settings.local.json too, and a legacy block there double-fires just as well.
+#
+# The script dir is archived, never deleted — and not while a registration
+# still points into it. Archiving out from under a live registration is worse
+# than the double-firing this replaces: the hook then resolves to a path that
+# no longer exists, and the run reports a successful archive.
+#
+# That pre-archive check is deliberately broader than the removal filter, to
+# catch a spelling nobody thought of ($CLAUDE_CONFIG_DIR, some other var) and
+# to cover the user's own scripts this block refuses to touch. Broader, not
+# blind: a command holding an ABSOLUTE path token that ends in .claude/hooks/
+# names some other checkout's hooks, not this user's dir, and must not block
+# the archive — otherwise a legitimate user-level hook pointing at
+# /some/project/.claude/hooks/x.sh warns on every run with nothing to act on.
+#
+# The wrapper (megavibe, "Auto-heal legacy USER-LEVEL hooks") carries the same
+# LEGACY_DEF and the same gate. Two copies, because setup.sh bootstraps the
+# machine the wrapper lives on — there is no shared library to put it in yet.
+# Edit both or neither.
+#
+# Known gaps: a $CLAUDE_CONFIG_DIR pointing somewhere other than ~/.claude is
+# not handled (this whole block is $HOME-anchored), and a Windows-style
+# backslash spelling matches nothing.
+#
+# Idempotent: re-runs find nothing to clean and print nothing.
 LEGACY_HOOK_DIR="$HOME/.claude/hooks"
-if command -v jq &>/dev/null && [ -f "$USER_SETTINGS" ]; then
-  if jq -e '.hooks' "$USER_SETTINGS" >/dev/null 2>&1; then
-    jq 'del(.hooks)' "$USER_SETTINGS" > "${USER_SETTINGS}.tmp" && \
-      mv "${USER_SETTINGS}.tmp" "$USER_SETTINGS"
-    ok "removed legacy .hooks block from ~/.claude/settings.json (project-level still active)"
+LEGACY_HOOK_NAMES='["after-edit.sh","agent-log.sh","augment-search.sh","block-dangerous-bash.sh","block-plan-mode.sh","block-stray-working-context.sh","codex-approval-never.sh","compaction-autopilot.sh","enforce-pr-format.sh","kube-token.sh","log-tool-event.sh","nudge-native-tools.sh","nudge-quiet-bash.sh","nudge-restart.sh","on-compact.sh","on-pre-compact.sh","on-session-end.sh","on-session-start.sh","read-delta.sh","redact-secrets.sh","reindex-agent.sh","resize-image.sh","revive-watcher.sh","rm-to-trash.sh","session-start.sh","snapshot.sh","start-context-watcher.sh","start-poma-serve.sh","truncate-verbose-bash.sh"]'
+# Shared by the detection pass, the filter and the pre-archive check, so they
+# cannot disagree. Applies to a hook entry; non-string .command (a list, a
+# schema that grows) is skipped rather than crashing jq, which would abort the
+# cleanup for the whole file and leave real legacy entries in place.
+LEGACY_DEF='
+  def cmd: .command | if type == "string" then . else "" end;
+  # $CLAUDE_PROJECT_DIR is neutralised, not excluded. A blanket
+  # contains("CLAUDE_PROJECT_DIR") test let ANY command mentioning it past the
+  # archive gate — including "$HOME/.claude/hooks/notify.sh \"$CLAUDE_PROJECT_DIR\"",
+  # an ordinary thing to write — and the dir was then archived out from under
+  # a live registration, reported as a heal. Rewritten to an absolute token it
+  # keeps $CLAUDE_PROJECT_DIR/.claude/hooks/x.sh non-blocking on its own merits.
+  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?"; "/__project__");
+  def in_hookdir: norm as $c
+    | ($c | contains($home + "/.claude/hooks/"))
+      or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
+      or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
+  # One occurrence must satisfy BOTH halves: the text before it has to be a
+  # user-level hooks-dir prefix, the text after it a shell terminator or the
+  # end of the string. Testing the two halves independently deleted
+  # "~/.claude/hooks/mine.sh /opt/other/.claude/hooks/log-tool-event.sh" —
+  # in_hookdir from the first path, ours from the second. split() rather than
+  # a regex so the 29 names need no escaping.
+  #
+  # Residual, accepted: a user hook that passes one of OUR paths as an
+  # argument ("mine.sh --fallback ~/.claude/hooks/agent-log.sh") still reads
+  # as legacy. Separating that from "bash ~/.claude/hooks/agent-log.sh" needs
+  # to know which token is the command, i.e. an interpreter list, which is
+  # more machinery than a bootstrapper should carry. The backup written before
+  # the rewrite is the recovery path.
+  def legacy: norm as $c
+    | any($names[];
+        (".claude/hooks/" + .) as $needle
+        | ($c | split($needle)) as $parts
+        | ($parts | length) > 1
+          and any(range(0; ($parts | length) - 1);
+                . as $i
+                | ($parts[$i+1] | . == "" or (.[0:1] | test("[ \t\r\n\"\u0027;|&<>,)]")))
+                  and ($parts[$i]
+                       | . == ""
+                         or endswith($home + "/")
+                         or test("(^|[ \t\"\u0027;|&(])((\\$HOME|\\$\\{HOME\\}|\"\\$HOME\"|~|\\.)/)?$"))));
+  def references_hookdir: norm as $c
+    | ($c | contains(".claude/hooks/"))
+      and (in_hookdir or ($c | test("(^|[ \t\"\u0027])/[^ \t\"\u0027]*\\.claude/hooks/") | not));
+'
+# Returns 0 always — a settings file this cannot parse or rewrite is left
+# alone, never a reason to abort the bootstrap.
+clean_legacy_hooks() {
+  local f="$1" found stamp
+  [ -f "$f" ] || return 0
+  found=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" "$LEGACY_DEF"'
+      [ .hooks? // {} | .. | objects | select(legacy) ] | length > 0
+    ' "$f" 2>/dev/null || echo false)
+  [ "$found" = "true" ] || return 0
+  # Every branch tolerates a shape it did not expect — a non-array event
+  # value, a non-object element — instead of throwing. A throw here aborts
+  # the rewrite for the WHOLE file, so one malformed neighbour would leave
+  # a real legacy entry in place, silently.
+  # Braced so the SHELL's own redirect failure (read-only ~/.claude) is caught
+  # too, not just jq's stderr — otherwise a raw "Permission denied" line lands
+  # in front of the launcher's own message.
+  if { jq --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" "$LEGACY_DEF"'
+        if (.hooks | type) != "object" then .
+        else
+          .hooks |= (
+            with_entries(
+              .value |= (
+                if type != "array" then .
+                else map(
+                  if type != "object" then .
+                  elif (.hooks | type) == "array"
+                  then (.hooks |= map(select(if type == "object" then legacy | not else true end)))
+                       | select((.hooks | length) > 0)
+                  elif legacy then empty
+                  else .
+                  end
+                )
+                end
+              )
+            )
+            | with_entries(select((.value | type) != "array" or (.value | length) > 0))
+          )
+          | if .hooks == {} then del(.hooks) else . end
+        end
+      ' "$f" > "${f}.tmp"; } 2>/dev/null \
+     && jq -e . "${f}.tmp" >/dev/null 2>&1 \
+     && ! jq -e --slurpfile new "${f}.tmp" '. == $new[0]' "$f" >/dev/null 2>&1; then
+    # Timestamped, because .megavibe-backup is rewritten on every run and so
+    # survives exactly one further setup.sh. This is the only copy of the
+    # removed registrations.
+    stamp=$(date +%Y%m%d-%H%M%S)
+    # If the backup cannot be written, nothing is rewritten. It is the only
+    # copy of the removed registrations — .megavibe-backup is overwritten on
+    # every setup run — so announcing a backup path that does not exist while
+    # discarding the original is the one outcome to rule out.
+    if ! cp "$f" "${f}.pre-hookclean-${stamp}" 2>/dev/null; then
+      warn "could not back up $(basename "$f") — left untouched, legacy entries still there"
+      rm -rf "${f}.tmp" 2>/dev/null || true
+      return 0
+    fi
+    # cp, not mv, and a guarded one. mv replaces a symlinked settings.json
+    # with a regular file, stranding the dotfiles copy it pointed at, and
+    # drops the file mode; and an mv that fails (immutable flag, ACL, a sync
+    # mount) exits the whole script under set -e — in the launcher that means
+    # claude never starts, with a fresh backup left behind on every attempt.
+    if ! cp "${f}.tmp" "$f" 2>/dev/null; then
+      warn "could not rewrite $(basename "$f") — left untouched, legacy entries still there"
+      rm -rf "${f}.tmp" "${f}.pre-hookclean-${stamp}" 2>/dev/null || true
+      return 0
+    fi
+    ok "removed legacy ~/.claude/hooks/ entries from $(basename "$f") (backup: $(basename "$f").pre-hookclean-${stamp})"
+  else
+    warn "$(basename "$f") has legacy ~/.claude/hooks/ registrations that could not be rewritten — left untouched, remove them by hand"
   fi
+  # Not "rm -f": a stale .tmp left as a DIRECTORY (killed run, sync client)
+  # makes rm exit 1, and set -e then aborts the whole bootstrap here — before
+  # MCP registration and everything after it.
+  rm -rf "${f}.tmp" 2>/dev/null || true
+}
+LEGACY_SETTINGS_FILES=("$USER_SETTINGS" "$HOME/.claude/settings.local.json")
+if command -v jq &>/dev/null; then
+  for f in "${LEGACY_SETTINGS_FILES[@]}"; do clean_legacy_hooks "$f"; done
 fi
 if [ -d "$LEGACY_HOOK_DIR" ]; then
-  ARCHIVE_DIR="${LEGACY_HOOK_DIR}.legacy-$(date +%Y%m%d)"
-  if [ ! -e "$ARCHIVE_DIR" ]; then
-    mv "$LEGACY_HOOK_DIR" "$ARCHIVE_DIR"
-    ok "archived legacy hook scripts to ${ARCHIVE_DIR}/"
+  # Three states, not two. "0" only when a check actually ran over every
+  # settings file present. "?" when it could not run at all — no jq, or jq
+  # failed — because archiving on a no-jq run strands every registration in a
+  # file nothing cleaned, which is the outcome the guard exists to prevent.
+  # jq_install can fail and still print ok, so this is reachable.
+  STILL_REFERENCED=0
+  if command -v jq &>/dev/null; then
+    for f in "${LEGACY_SETTINGS_FILES[@]}"; do
+      [ -f "$f" ] || continue
+      # Carries the offending command(s) with the count: a warn naming only a
+      # number, for a path the user cannot grep for, repeats every run with
+      # nothing to act on.
+      REF=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" \
+              --arg file "$(basename "$f")" "$LEGACY_DEF"'
+          [ .hooks? // {} | .. | objects | select(references_hookdir) | cmd ] as $c
+          | if ($c | length) == 0 then "0"
+            else "\($c | length) in \($file): \($c[0:2] | join("; "))"
+            end
+        ' "$f" 2>/dev/null || echo "?")
+      [ "$REF" = "0" ] || STILL_REFERENCED="$REF"
+    done
   else
-    rm -rf "$LEGACY_HOOK_DIR"
-    ok "removed legacy hook scripts (archive ${ARCHIVE_DIR}/ already exists)"
+    STILL_REFERENCED="?"
+  fi
+  if [ "$STILL_REFERENCED" = "?" ]; then
+    warn "left ${LEGACY_HOOK_DIR}/ in place — could not check ~/.claude settings for registrations pointing into it"
+  elif [ "$STILL_REFERENCED" != "0" ]; then
+    warn "left ${LEGACY_HOOK_DIR}/ in place — still referenced by ${STILL_REFERENCED}"
+  else
+    ARCHIVE_DIR="${LEGACY_HOOK_DIR}.legacy-$(date +%Y%m%d)"
+    # A same-day collision means the dir was archived once today and came
+    # back. The old code rm -rf'd the new copy, which is the one thing this
+    # branch promises not to do — second suffix instead.
+    [ -e "$ARCHIVE_DIR" ] && ARCHIVE_DIR="${LEGACY_HOOK_DIR}.legacy-$(date +%Y%m%d-%H%M%S)"
+    if [ ! -e "$ARCHIVE_DIR" ]; then
+      mv "$LEGACY_HOOK_DIR" "$ARCHIVE_DIR"
+      ok "archived legacy hook scripts to ${ARCHIVE_DIR}/"
+    else
+      warn "left ${LEGACY_HOOK_DIR}/ in place — ${ARCHIVE_DIR}/ already exists"
+    fi
   fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -962,11 +962,12 @@ LEGACY_DEF='
   # The lookahead keeps $CLAUDE_PROJECT_DIR_BACKUP — a DIFFERENT variable that
   # can point anywhere — from being rewritten to /__project___BACKUP and
   # inheriting the exemption.
-  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?(?![A-Za-z0-9_])"; "/__project__");
-  def in_hookdir: norm as $c
-    | at_boundary($c; $home + "/.claude/hooks/")
-      or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
-      or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
+  def nstr: gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?(?![A-Za-z0-9_])"; "/__project__");
+  def norm: cmd | nstr;
+  def in_hookdir_s($c): at_boundary($c; $home + "/.claude/hooks/")
+    or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
+    or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
+  def in_hookdir: in_hookdir_s(norm);
   # One occurrence must satisfy BOTH halves: the text before it has to be a
   # user-level hooks-dir prefix, the text after it a shell terminator or the
   # end of the string. Testing the two halves independently deleted
@@ -976,8 +977,8 @@ LEGACY_DEF='
   #
   # The expanded-$HOME prefix carries the same boundary requirement as every
   # other spelling: a bare endswith() deleted
-  # "/opt/mirror/Users/alice/.claude/hooks/agent-log.sh", a MIRROR of the
-  # user home under another root, which is a different directory entirely.
+  # "/opt/mirror$HOME/.claude/hooks/agent-log.sh", a MIRROR of the user home
+  # under another root, which is a different directory entirely.
   #
   # Residual, accepted: a user hook that passes one of OUR paths as an
   # argument ("mine.sh --fallback ~/.claude/hooks/agent-log.sh") still reads
@@ -1005,23 +1006,47 @@ LEGACY_DEF='
   # An occurrence is exempt only when its own prefix ends in an absolute path
   # token — unquoted and space-free, or quoted and then free to contain
   # spaces. Anything it cannot resolve blocks the archive: fail closed.
+  # Third alternative: "$HOME/dev/myproj/.claude/hooks/notify.sh" is an
+  # ordinary user-level registration of a PROJECT hook, and only the absolute
+  # spelling of it was exempt — so the $HOME spelling blocked the archive on
+  # every run forever, under a message telling the user to delete a
+  # registration that is doing its job. It needs at least one segment between
+  # $HOME and .claude/, so "$HOME/.claude/hooks/" — our own dir — still
+  # blocks (and in_hookdir catches that one first regardless).
   def other_checkout: test("(^|[ \t\r\n\"\u0027;|&(])/[^ \t\r\n\"\u0027;|&()]*$")
-    or test("(^|[ \t\r\n;|&(])[\"\u0027]/[^\"\u0027]*$");
-  def references_hookdir: norm as $c
-    | ($c | contains(".claude/hooks/"))
-      and (in_hookdir
-           or (($c | split(".claude/hooks/")) as $p
-               | any($p[0:-1][]; other_checkout | not)));
+    or test("(^|[ \t\r\n;|&(])[\"\u0027]/[^\"\u0027]*$")
+    or test("(^|[ \t\r\n\"\u0027;|&(])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/[^ \t\r\n\"\u0027;|&()]+/$");
+  def refs_s($c): ($c | contains(".claude/hooks/"))
+    and (in_hookdir_s($c)
+         or (($c | split(".claude/hooks/")) as $p
+             | any($p[0:-1][]; other_checkout | not)));
+  def references_hookdir: refs_s(norm);
+  # The pre-archive scan runs over every STRING in the document, not over
+  # .hooks entries. statusLine.command and apiKeyHelper point at a script the
+  # same way a hook does, and scoping the gate to .hooks archived the
+  # directory out from under them while printing "archived legacy hook
+  # scripts" — exactly the outcome this gate exists to prevent. Scanning
+  # strings also covers command keys that do not exist yet.
+  def references_hookdir_str: refs_s(nstr);
 '
 # Returns 0 always — a settings file this cannot parse or rewrite is left
 # alone, never a reason to abort the bootstrap.
 clean_legacy_hooks() {
-  local f="$1" found stamp
+  local f="$1" found stamp n_legacy cmds_legacy
   [ -f "$f" ] || return 0
+  # The detection pass also CARRIES the commands it matched, so the success
+  # line can name them. A removal the user disagrees with (their own script
+  # whose basename collides with one of the 29, or a command that merely
+  # mentions a hook path) is otherwise silent, and the backup they would need
+  # is only findable if they know something was taken.
   found=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" "$LEGACY_DEF"'
-      [ .hooks? // {} | .. | objects | select(legacy) ] | length > 0
-    ' "$f" 2>/dev/null || echo false)
-  [ "$found" = "true" ] || return 0
+      [ .hooks? // {} | .. | objects | select(legacy) | cmd ] as $c
+      | "\($c | length)\n\($c[0:3] | map(gsub("\\s+"; " ")) | join("; "))"
+    ' "$f" 2>/dev/null || printf "0\n")
+  n_legacy=$(printf '%s' "$found" | sed -n 1p)
+  cmds_legacy=$(printf '%s' "$found" | sed -n 2p)
+  case "$n_legacy" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$n_legacy" -gt 0 ] || return 0
   # Cleared BEFORE the redirect, not only after: a leftover settings.json.tmp
   # that is a SYMLINK makes the redirect write through it into whatever it
   # points at, and one that is a DIRECTORY makes the redirect fail. Neither is
@@ -1087,7 +1112,7 @@ clean_legacy_hooks() {
       rm -rf "${f}.tmp" 2>/dev/null || true
       return 0
     fi
-    ok "removed legacy ~/.claude/hooks/ entries from $(basename "$f") (backup: $(basename "$f").pre-hookclean-${stamp})"
+    ok "removed ${n_legacy} legacy ~/.claude/hooks/ registration(s) from $(basename "$f") — ${cmds_legacy} (backup: $(basename "$f").pre-hookclean-${stamp})"
   else
     warn "$(basename "$f") has legacy ~/.claude/hooks/ registrations that could not be rewritten — left untouched, remove them by hand"
   fi
@@ -1118,7 +1143,7 @@ if [ -d "$LEGACY_HOOK_DIR" ]; then
       # nothing to act on.
       REF=$(jq -r --arg home "$HOME" --argjson names "$LEGACY_HOOK_NAMES" \
               --arg file "$(basename "$f")" "$LEGACY_DEF"'
-          [ .hooks? // {} | .. | objects | select(references_hookdir) | cmd ] as $c
+          [ .. | strings | select(references_hookdir_str) ] as $c
           | if ($c | length) == 0 then "0"
             else "\($c | length) in \($file): \($c[0:2] | join("; "))"
             end

--- a/setup.sh
+++ b/setup.sh
@@ -946,15 +946,25 @@ LEGACY_HOOK_NAMES='["after-edit.sh","agent-log.sh","augment-search.sh","block-da
 # cleanup for the whole file and leave real legacy entries in place.
 LEGACY_DEF='
   def cmd: .command | if type == "string" then . else "" end;
+  # A path token in a shell command starts at the string start or after one of
+  # these. Used as the left boundary everywhere, so no predicate can match a
+  # path that merely CONTAINS ours as a substring.
+  def bnd: . == "" or (.[-1:] | test("[ \t\r\n\"\u0027;|&(]"));
+  def at_boundary($c; $needle):
+    ($c | split($needle)) as $p
+    | ($p | length) > 1 and any($p[0:-1][]; bnd);
   # $CLAUDE_PROJECT_DIR is neutralised, not excluded. A blanket
   # contains("CLAUDE_PROJECT_DIR") test let ANY command mentioning it past the
   # archive gate — including "$HOME/.claude/hooks/notify.sh \"$CLAUDE_PROJECT_DIR\"",
   # an ordinary thing to write — and the dir was then archived out from under
   # a live registration, reported as a heal. Rewritten to an absolute token it
   # keeps $CLAUDE_PROJECT_DIR/.claude/hooks/x.sh non-blocking on its own merits.
-  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?"; "/__project__");
+  # The lookahead keeps $CLAUDE_PROJECT_DIR_BACKUP — a DIFFERENT variable that
+  # can point anywhere — from being rewritten to /__project___BACKUP and
+  # inheriting the exemption.
+  def norm: cmd | gsub("\\$\\{?CLAUDE_PROJECT_DIR\\}?(?![A-Za-z0-9_])"; "/__project__");
   def in_hookdir: norm as $c
-    | ($c | contains($home + "/.claude/hooks/"))
+    | at_boundary($c; $home + "/.claude/hooks/")
       or ($c | test("(^|[^A-Za-z0-9_/])\"?(\\$HOME|\\$\\{HOME\\}|~)\"?/\\.claude/hooks/"))
       or ($c | test("(^|[ \t\r\n\"\u0027;|&(])\\.?/?\\.claude/hooks/"));
   # One occurrence must satisfy BOTH halves: the text before it has to be a
@@ -963,6 +973,11 @@ LEGACY_DEF='
   # "~/.claude/hooks/mine.sh /opt/other/.claude/hooks/log-tool-event.sh" —
   # in_hookdir from the first path, ours from the second. split() rather than
   # a regex so the 29 names need no escaping.
+  #
+  # The expanded-$HOME prefix carries the same boundary requirement as every
+  # other spelling: a bare endswith() deleted
+  # "/opt/mirror/Users/alice/.claude/hooks/agent-log.sh", a MIRROR of the
+  # user home under another root, which is a different directory entirely.
   #
   # Residual, accepted: a user hook that passes one of OUR paths as an
   # argument ("mine.sh --fallback ~/.claude/hooks/agent-log.sh") still reads
@@ -977,14 +992,26 @@ LEGACY_DEF='
         | ($parts | length) > 1
           and any(range(0; ($parts | length) - 1);
                 . as $i
-                | ($parts[$i+1] | . == "" or (.[0:1] | test("[ \t\r\n\"\u0027;|&<>,)]")))
+                | ($parts[$i+1] | . == "" or (.[0:1] | test("[ \t\r\n\"\u0027;|&<>)]")))
                   and ($parts[$i]
-                       | . == ""
-                         or endswith($home + "/")
-                         or test("(^|[ \t\"\u0027;|&(])((\\$HOME|\\$\\{HOME\\}|\"\\$HOME\"|~|\\.)/)?$"))));
+                       | (endswith($home + "/")
+                          and (.[0:(length - ($home | length) - 1)] | bnd))
+                         or test("(^|[ \t\r\n\"\u0027;|&(])(\"?(\\$HOME|\\$\\{HOME\\}|~|\\.)\"?/)?$"))));
+  # Broader than the removal filter, and evaluated PER OCCURRENCE. Deciding it
+  # over the whole string let one unrelated absolute path cancel the
+  # protection for a live reference beside it:
+  # "${HOOK_ROOT}/.claude/hooks/notify.sh /opt/project/.claude/hooks/other.sh"
+  # read as exempt and the directory was archived out from under notify.sh.
+  # An occurrence is exempt only when its own prefix ends in an absolute path
+  # token — unquoted and space-free, or quoted and then free to contain
+  # spaces. Anything it cannot resolve blocks the archive: fail closed.
+  def other_checkout: test("(^|[ \t\r\n\"\u0027;|&(])/[^ \t\r\n\"\u0027;|&()]*$")
+    or test("(^|[ \t\r\n;|&(])[\"\u0027]/[^\"\u0027]*$");
   def references_hookdir: norm as $c
     | ($c | contains(".claude/hooks/"))
-      and (in_hookdir or ($c | test("(^|[ \t\"\u0027])/[^ \t\"\u0027]*\\.claude/hooks/") | not));
+      and (in_hookdir
+           or (($c | split(".claude/hooks/")) as $p
+               | any($p[0:-1][]; other_checkout | not)));
 '
 # Returns 0 always — a settings file this cannot parse or rewrite is left
 # alone, never a reason to abort the bootstrap.
@@ -995,6 +1022,11 @@ clean_legacy_hooks() {
       [ .hooks? // {} | .. | objects | select(legacy) ] | length > 0
     ' "$f" 2>/dev/null || echo false)
   [ "$found" = "true" ] || return 0
+  # Cleared BEFORE the redirect, not only after: a leftover settings.json.tmp
+  # that is a SYMLINK makes the redirect write through it into whatever it
+  # points at, and one that is a DIRECTORY makes the redirect fail. Neither is
+  # hypothetical after a killed run or a file-sync client.
+  rm -rf "${f}.tmp" 2>/dev/null || true
   # Every branch tolerates a shape it did not expect — a non-array event
   # value, a non-object element — instead of throwing. A throw here aborts
   # the rewrite for the WHOLE file, so one malformed neighbour would leave
@@ -1047,8 +1079,12 @@ clean_legacy_hooks() {
     # mount) exits the whole script under set -e — in the launcher that means
     # claude never starts, with a fresh backup left behind on every attempt.
     if ! cp "${f}.tmp" "$f" 2>/dev/null; then
-      warn "could not rewrite $(basename "$f") — left untouched, legacy entries still there"
-      rm -rf "${f}.tmp" "${f}.pre-hookclean-${stamp}" 2>/dev/null || true
+      # The backup is KEPT. cp can truncate or partially write the
+      # destination before failing, so this branch is exactly where the only
+      # surviving copy matters — deleting it turned a failed rewrite into
+      # unrecoverable loss of the whole settings file.
+      warn "could not rewrite $(basename "$f") — backup kept at $(basename "$f").pre-hookclean-${stamp}"
+      rm -rf "${f}.tmp" 2>/dev/null || true
       return 0
     fi
     ok "removed legacy ~/.claude/hooks/ entries from $(basename "$f") (backup: $(basename "$f").pre-hookclean-${stamp})"
@@ -1065,12 +1101,15 @@ if command -v jq &>/dev/null; then
   for f in "${LEGACY_SETTINGS_FILES[@]}"; do clean_legacy_hooks "$f"; done
 fi
 if [ -d "$LEGACY_HOOK_DIR" ]; then
-  # Three states, not two. "0" only when a check actually ran over every
-  # settings file present. "?" when it could not run at all — no jq, or jq
-  # failed — because archiving on a no-jq run strands every registration in a
-  # file nothing cleaned, which is the outcome the guard exists to prevent.
-  # jq_install can fail and still print ok, so this is reachable.
+  # Three states, not two. STILL_REFERENCED=0 only when a check actually ran
+  # over every settings file present; CHECK_FAILED=1 when it could not run at
+  # all — no jq, or jq failed — because archiving on a no-jq run strands every
+  # registration in a file nothing cleaned, which is the outcome the guard
+  # exists to prevent. jq_install can fail and still print ok, so this is
+  # reachable. A separate flag rather than a "?" sentinel in the same
+  # variable, so a real reference string can never be mistaken for it.
   STILL_REFERENCED=0
+  CHECK_FAILED=0
   if command -v jq &>/dev/null; then
     for f in "${LEGACY_SETTINGS_FILES[@]}"; do
       [ -f "$f" ] || continue
@@ -1084,12 +1123,20 @@ if [ -d "$LEGACY_HOOK_DIR" ]; then
             else "\($c | length) in \($file): \($c[0:2] | join("; "))"
             end
         ' "$f" 2>/dev/null || echo "?")
-      [ "$REF" = "0" ] || STILL_REFERENCED="$REF"
+      # Accumulated, not overwritten. With a reference in settings.json AND
+      # one in settings.local.json, the second assignment used to hide the
+      # first and the user fixed half the problem.
+      if [ "$REF" = "?" ]; then
+        CHECK_FAILED=1
+      elif [ "$REF" != "0" ]; then
+        if [ "$STILL_REFERENCED" = "0" ]; then STILL_REFERENCED="$REF"
+        else STILL_REFERENCED="${STILL_REFERENCED}; ${REF}"; fi
+      fi
     done
   else
-    STILL_REFERENCED="?"
+    CHECK_FAILED=1
   fi
-  if [ "$STILL_REFERENCED" = "?" ]; then
+  if [ "$CHECK_FAILED" = "1" ]; then
     warn "left ${LEGACY_HOOK_DIR}/ in place — could not check ~/.claude settings for registrations pointing into it"
   elif [ "$STILL_REFERENCED" != "0" ]; then
     warn "left ${LEGACY_HOOK_DIR}/ in place — still referenced by ${STILL_REFERENCED}"
@@ -1100,8 +1147,15 @@ if [ -d "$LEGACY_HOOK_DIR" ]; then
     # branch promises not to do — second suffix instead.
     [ -e "$ARCHIVE_DIR" ] && ARCHIVE_DIR="${LEGACY_HOOK_DIR}.legacy-$(date +%Y%m%d-%H%M%S)"
     if [ ! -e "$ARCHIVE_DIR" ]; then
-      mv "$LEGACY_HOOK_DIR" "$ARCHIVE_DIR"
-      ok "archived legacy hook scripts to ${ARCHIVE_DIR}/"
+      # Guarded: an unguarded mv that fails (parent-dir ACL, immutable flag,
+      # a sync mount) exits non-zero under set -e, which in setup.sh aborts
+      # the bootstrap before MCP registration and in the launcher means claude
+      # never starts.
+      if mv "$LEGACY_HOOK_DIR" "$ARCHIVE_DIR" 2>/dev/null; then
+        ok "archived legacy hook scripts to ${ARCHIVE_DIR}/"
+      else
+        warn "left ${LEGACY_HOOK_DIR}/ in place — could not move it to ${ARCHIVE_DIR}/"
+      fi
     else
       warn "left ${LEGACY_HOOK_DIR}/ in place — ${ARCHIVE_DIR}/ already exists"
     fi


### PR DESCRIPTION
## Summary

`setup.sh` §5b and the launcher's auto-heal both existed to remove pre-2026-04 user-level hook registrations, which double-fire against today's project-level hooks. They were too blunt in one direction and too narrow in another: `setup.sh` deleted every user-level hook including ones the user added deliberately, while the launcher matched only one spelling of the path and archived the hook directory unconditionally. This makes removal precise, makes the two healers agree, and stops the archive stranding anything still pointing into that directory.

## Bug

Four separate failures, each reproduced before fixing.

**Deleted hooks it had no business touching.** `jq 'del(.hooks)'` removed the entire `.hooks` key from `~/.claude/settings.json` — a user-level hook pointing at `/opt/mine/notify.sh` went with it. Recoverable only from `settings.json.megavibe-backup`, which the next run overwrites.

**Missed the spelling that was actually in the wild.** The launcher matched only the expanded `$HOME` path, so a registration written `"$HOME/.claude/hooks/enforce-pr-format.sh"` survived it. A relative `.claude/hooks/x.sh` — what this project's own template emits — was missed by both; in user scope it resolves against whatever project is cwd, which is the double-fire itself.

**Archived the directory out from under live registrations.** `~/.claude/hooks/` was moved to `hooks.legacy-YYYYMMDD` whenever it existed, with no check that anything still referenced it. Any registration the matcher missed then pointed at a path that no longer existed, and the run reported a successful archive. On a same-day collision the old code `rm -rf`'d the new copy outright.

**Aborted the run on ordinary filesystem states.** `rm -f "$settings.tmp"` exits 1 when a stale `.tmp` exists as a directory, and `set -euo pipefail` then killed the script — in `setup.sh` before MCP registration, in the launcher before claude starts.

## Fix

Removal requires two conditions: the command references the user-level hooks dir, and its basename is one megavibe has ever shipped — a frozen 29-name list built from `git log --all --diff-filter=A`. It never needs updating, since new hooks are registered per-project and cannot appear in a legacy block. One occurrence must satisfy both halves, prefix before and shell terminator after, so two unrelated matches in a single command cannot combine.

Matching is boundary-anchored rather than substring, so `/opt/my~/.claude/hooks/x.sh`, `$CLAUDE_PROJECT_DIR/.claude/hooks/x.sh` and another checkout's absolute path all survive. Spellings covered: expanded `$HOME`, `$HOME/`, `${HOME}/`, `~/`, the quoted `"$HOME"/` form, and a relative `.claude/hooks/` at any shell token boundary.

The archive is gated on nothing still referencing the directory — a check deliberately broader than the removal filter, to catch a spelling nobody thought of, but not blind: an absolute path token ending in `.claude/hooks/` names some other checkout and does not block. `$CLAUDE_PROJECT_DIR` is neutralised for that check rather than excluded, because a blanket exclusion let a hook passing it as an argument slip through. It fails closed when the check cannot run, and a same-day collision takes a second suffix instead of deleting.

Both `~/.claude/settings.json` and `settings.local.json` are scanned, each backed up to `.pre-hookclean-<stamp>` before rewrite. The write is `cp`-through, so a symlinked `settings.json` stays a symlink pointing at the user's dotfiles; a failed backup or write aborts that file rather than exiting the script. The filter tolerates unexpected shapes instead of throwing, since one malformed neighbour previously left real legacy entries in place silently.

The launcher now carries the identical `LEGACY_DEF` and name list, asserted byte-identical, so it no longer undoes `setup.sh`'s guard on the next launch. It stays silent in every steady state except one line, once, for the case where something still points into the directory and cannot be healed.

Known and documented in both files: a user hook passing one of our own hook paths as an argument still reads as legacy — separating that from `bash ~/.claude/hooks/x.sh` needs to know which token is the command. `$CLAUDE_CONFIG_DIR` outside `~/.claude` and Windows backslash spellings are not handled.

## Verification

38 fixtures across both blocks under a fake `HOME`, each run twice: ten spellings removed, nine kept, all idempotent and byte-identical on the second run. Plus the `$CLAUDE_PROJECT_DIR` archive gate, the read-only-directory path (exit 0, no leftovers, no raw `Permission denied`), symlink preservation, the no-`jq` path leaving the directory alone, the same-day collision, and malformed-shape tolerance (non-array event value, non-object element, non-string command, invalid JSON).

Four review rounds — Gemini `--pro` ×3 and the `reviewer` subagent ×3 — each of which found real defects that are fixed here. Codex was unavailable throughout: the npm-global `@openai/codex` is missing its `darwin-arm64` optional dependency.

https://claude.ai/code/session_01J9rEk4JPpVg22L6dpRWd5n
